### PR TITLE
Undefined name: 'yara_file' --> 'taste_yara_file?

### DIFF
--- a/server/objects.py
+++ b/server/objects.py
@@ -380,6 +380,7 @@ class StrelkaFile(object):
             yara_file: Location of the YARA file that contains rules used
                 to taste files.
         """
+        taste_yara_file = None
         try:
             global compiled_yara
             if compiled_yara is None:
@@ -395,7 +396,7 @@ class StrelkaFile(object):
         except (yara.Error, yara.TimeoutError) as YaraError:
             self.flags.append("StrelkaFile::yara_scan_error")
             logging.exception("Exception while tasting with YARA file"
-                              f" {yara_file} (see traceback below)")
+                              f" {taste_yara_file} (see traceback below)")
 
 
 class StrelkaScanner(object):


### PR DESCRIPTION
__yara_file__ is an _undefined name_ in this context which will probably raise a NameError instead of the expected exceptions.

[flake8](http://flake8.pycqa.org) testing of https://github.com/target/strelka on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./server/objects.py:397:32: F821 undefined name 'yara_file'
            logging.exception("Exception while tasting with YARA file"
                               ^
1     F821 undefined name 'yara_file'
1
```

**Describe the change**
Include a summary of the change (with required dependencies), any issues it fixes, and relevant motivation and context.

**Describe testing procedures**
Describe the tests that you ran to verify your changes (including test configurations) and instructions so we can reproduce the tests. To assist in testing, the project maintainers may ask for file samples.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
