### PR TITLE
Add option to deobfuscate JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2018-10-03
+### Added
+- ScanJavascript now supports deobfuscating JavaScript files before parsing metadata (Josh Liburdi)
+
 ## 2018-09-28
 ### Added
 - ScanUrl now supports user-defined regular expressions that can be called per-file (Josh Liburdi)

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get -qq update && \
     inflection \
     inotify_simple \
     interruptingcow \
+    jsbeautifier \
     libarchive-c \
     lxml \
     git+https://github.com/aaronst/macholibre.git \

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The recommended operating system for Strelka is Ubuntu 18.04 LTS (Bionic Beaver)
 
 2. Install pip3 packages
     ```sh
-    pip3 install beautifulsoup4 boltons boto3 gevent google-cloud-storage html5lib inflection inotify_simple interruptingcow libarchive-c lxml git+https://github.com/aaronst/macholibre.git olefile oletools pdfminer.six pefile pgpdump3 protobuf pyelftools pygments pyjsparser pylzma git+https://github.com/jshlbrd/pyopenssl.git python-docx git+https://github.com/jshlbrd/python-entropy.git python-keystoneclient python-magic python-swiftclient pyyaml pyzmq rarfile requests rpmfile schedule ssdeep tnefparse
+    pip3 install beautifulsoup4 boltons boto3 gevent google-cloud-storage html5lib inflection inotify_simple interruptingcow jsbeautifier libarchive-c lxml git+https://github.com/aaronst/macholibre.git olefile oletools pdfminer.six pefile pgpdump3 protobuf pyelftools pygments pyjsparser pylzma git+https://github.com/jshlbrd/pyopenssl.git python-docx git+https://github.com/jshlbrd/python-entropy.git python-keystoneclient python-magic python-swiftclient pyyaml pyzmq rarfile requests rpmfile schedule ssdeep tnefparse
     ```
 
 3. Install YARA
@@ -655,7 +655,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanHeader | Collects file header | "length" -- number of header characters to log as metadata (defaults to 50) |
 | ScanHtml | Collects metadata and extracts embedded files from HTML files | "parser" -- sets the HTML parser used during scanning (defaults to "html.parser") |
 | ScanJarManifest | Collects metadata from JAR manifest files | N/A |
-| ScanJavascript | Collects metadata from Javascript files | N/A |
+| ScanJavascript | Collects metadata from Javascript files | "beautify" -- deobfuscates JavaScript before parsing (defaults to True) |
 | ScanJpeg | Extracts data embedded in JPEG files | N/A |
 | ScanJson | Collects keys from JSON files | N/A |
 | ScanLibarchive | Extracts files from libarchive-compatible archives. | "limit" -- maximum number of files to extract (defaults to 1000) |

--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -212,6 +212,8 @@ scan:
             - 'javascript_file'
             - 'javascript'
         priority: 5
+        options:
+          beautify: True
     'ScanJpeg':
       - positive:
           flavors:

--- a/server/scanners/scan_javascript.py
+++ b/server/scanners/scan_javascript.py
@@ -1,18 +1,30 @@
+import jsbeautifier
 import pyjsparser
 
 from server import objects
 
 
 class ScanJavascript(objects.StrelkaScanner):
-    """Collects metadata from JavaScript files."""
+    """Collects metadata from JavaScript files.
+
+    Options:
+        beautify: Boolean that determines if JavaScript should be deobfuscated.
+            Defaults to True.
+    """
     def scan(self, file_object, options):
+        beautify = options.get("beautify", True)
+
         self.metadata.setdefault("literals", [])
         self.metadata.setdefault("functions", [])
         self.metadata.setdefault("variables", [])
 
         try:
-            p = pyjsparser.PyJsParser()
-            parsed = p.parse(file_object.data.decode())
+            if beautify:
+                js = jsbeautifier.beautify(file_object.data.decode())
+            else:
+                js = file_object.data.decode()
+            parser = pyjsparser.PyJsParser()
+            parsed = parser.parse(js)
             self._javascript_recursion(self, parsed)
 
         except AttributeError:


### PR DESCRIPTION
**Describe the change**
This PR adds an option to deobfuscate JavaScript files. Enabling this option should improve the JavaScript parsing — by default, it will be enabled.

**Describe testing procedures**
Tested with complex JavaScript files and compared the beautified and raw JavaScript content. All option settings (True, False, null) were also tested.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
