### PR TITLE
jshlbrd/pdf-extract-bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2018-10-05
+### Changed
+- ScanPdf was unintentionally extracting duplicate streams, but now it is fixed to only extract unique streams (Josh Liburdi)
+
 ## 2018-10-03
 ### Added
 - ScanJavascript now supports deobfuscating JavaScript files before parsing metadata (Josh Liburdi)

--- a/server/scanners/scan_pdf.py
+++ b/server/scanners/scan_pdf.py
@@ -28,6 +28,7 @@ class ScanPdf(objects.StrelkaScanner):
         file_limit = options.get("limit", 2000)
 
         self.metadata["total"] = {"objects": 0, "extracted": 0}
+        extracted_objects = set()
 
         try:
             with io.BytesIO(file_object.data) as pdf_object:
@@ -71,8 +72,9 @@ class ScanPdf(objects.StrelkaScanner):
                                                                    parent_hash=file_object.hash,
                                                                    root_hash=file_object.root_hash,
                                                                    source=self.scanner_name)
-                                    if child_fo not in self.children:
+                                    if object_id not in extracted_objects:
                                         self.children.append(child_fo)
+                                        extracted_objects.add(object_id)
                                         self.metadata["total"]["extracted"] += 1
 
                                 except TypeError:


### PR DESCRIPTION
**Describe the change**
This PR fixes a bug found in the ScanPdf stream extraction that caused duplicate streams to be extracted.

**Describe testing procedures**
Tested with a PDF file that had the same stream referenced in multiple locations, which led to duplicate file extraction.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
