### PR TITLE
jshlbrd/scan-strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Changes to the project will be tracked in this file via the date of change.
 
 ## 2018-10-05
+### Added
+- New scanner ScanStrings can collect strings from file data (similar to Unix "strings" utility)
 ### Changed
 - ScanPdf was unintentionally extracting duplicate streams, but now it is fixed to only extract unique streams (Josh Liburdi)
 

--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanRpm | Collects metadata and extracts files from RPM files | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/") |
 | ScanRtf | Extracts embedded files from RTF files | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanSelf | Collects metadata from the file's internal attributes | N/A |
+| ScanStrings | Collects strings from file data | "limit" -- maximum number of strings to collect, starting from the beginning of the file (defaults to 0, collects all strings) |
 | ScanSwf | Decompresses swf (Flash) files | N/A |
 | ScanTar | Extract files from tar archives | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanTnef | Collects metadata and extract files from TNEF files | N/A |

--- a/server/scanners/scan_strings.py
+++ b/server/scanners/scan_strings.py
@@ -1,0 +1,27 @@
+import re
+
+from server import objects
+
+
+class ScanStrings(objects.StrelkaScanner):
+    """Collects strings from files.
+
+    Collects strings from files (similar to the output of the Unix "strings"
+    utility).
+
+    Options:
+        limit: Maximum number of strings to collect, starting from the
+            beginning of the file. If this value is 0, then all strings are
+            collected.
+            Defaults to 0 (unlimited).
+    """
+    def init(self):
+        self.strings_regex = re.compile(br"[^\x00-\x1F\x7F-\xFF]{4,}")
+
+    def scan(self, file_object, options):
+        limit = options.get("limit", 0)
+
+        strings = self.strings_regex.findall(file_object.data)
+        if limit:
+            strings = strings[:limit]
+        self.metadata["strings"] = strings


### PR DESCRIPTION
**Describe the change**
Adds ScanStrings scanner, this can be used to collect strings (similar to Unix “strings” utility) from file data.

**Describe testing procedures**
Tested using a variety of files, including testing the limit option.

**Sample output**
```
cat /var/log/strelka/AA0E3-B0238.log | jq .results[].stringsMetadata
{
  "strings": [
    "!This program cannot be run in DOS mode.",
    "Rich",
    ".text",
    "`.rdata",
    "@.data",
    ".ndata",
    ".rsrc",
    "507B",
    "5Lp@",
    "h /B"
  ]
}
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
