### PR TITLE
jshlbrd/scan-php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2018-10-16
+### Added
+- New scanner ScanPhp can collect tokenized metadata from PHP files
+
 ## 2018-10-05
 ### Added
 - New scanner ScanStrings can collect strings from file data (similar to Unix "strings" utility)

--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanPdf | Collects metadata and extracts streams from PDF files | "extract_text" -- boolean that determines if document text should be extracted as a child file (defaults to False)<br>"limit" -- maximum number of files to extract (defaults to 2000) |
 | ScanPe | Collects metadata from PE files | N/A |
 | ScanPgp | Collects metadata from PGP files | N/A |
+| ScanPhp | Collects metadata from PHP files | N/A |
 | ScanPkcs7 | Extracts files from PKCS7 certificate files | N/A |
 | ScanRar | Extracts files from RAR archives | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanRpm | Collects metadata and extracts files from RPM files | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/") |

--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -291,6 +291,12 @@ scan:
         options:
           extract_text: False
           limit: 2000
+    'ScanPhp':
+      - positive:
+          flavors:
+            - 'php_file'
+            - 'text/x-php'
+        priority: 5
     'ScanPe':
       - positive:
           flavors:

--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -294,8 +294,8 @@ scan:
     'ScanPhp':
       - positive:
           flavors:
-            - 'php_file'
             - 'text/x-php'
+            - 'php_file'
         priority: 5
     'ScanPe':
       - positive:

--- a/etc/strelka/taste.yara
+++ b/etc/strelka/taste.yara
@@ -678,6 +678,16 @@ rule json_file
         $a at 0
 }
 
+rule php_file
+{
+    meta:
+        type = "text"
+    strings:
+        $a = { 3c 3f 70 68 70 }
+    condition:
+        $a at 0
+}
+
 rule soap_file
 {
     meta:

--- a/server/scanners/scan_php.py
+++ b/server/scanners/scan_php.py
@@ -1,0 +1,62 @@
+import pygments
+from pygments import formatters
+from pygments import lexers
+
+from server import objects
+
+
+class ScanPhp(objects.StrelkaScanner):
+    """Collects metadata from PHP files.
+
+    Pygments is used as a lexer and the tokenized data is appended as metadata.
+
+    Attributes:
+        lexer: Pygments lexer ("php") used to parse the file.
+    """
+    def init(self):
+        self.lexer = lexers.get_lexer_by_name("php")
+
+    def scan(self, file_object, options):
+        highlight = pygments.highlight(file_object.data,
+                                       self.lexer,
+                                       formatters.RawTokenFormatter())
+        highlight_list = highlight.split(b"\n")
+
+        ordered_highlights = []
+        for hl in highlight_list:
+            split_highlight = hl.split(b"\t")
+            if len(split_highlight) == 2:
+                token = split_highlight[0].decode()
+                value = split_highlight[1].decode().strip("'\"").strip()
+                highlight_entry = {"token": token, "value": value}
+                if highlight_entry["value"]:
+                    ordered_highlights.append(highlight_entry)
+
+        self.metadata.setdefault("tokens", [])
+        self.metadata.setdefault("builtins", [])
+        self.metadata.setdefault("operators", [])
+        self.metadata.setdefault("strings", [])
+        self.metadata.setdefault("variables", [])
+
+        position = 0
+        while position < len(ordered_highlights):
+            ohlp = ordered_highlights[position]
+            if ohlp["token"] not in self.metadata["tokens"]:
+                self.metadata["tokens"].append(ohlp["token"])
+            if ohlp["token"] == "Token.Name.Builtin":
+                if ohlp["value"] not in self.metadata["builtins"]:
+                    self.metadata["builtins"].append(ohlp["value"])
+            elif ohlp["token"] == "Token.Operator":
+                if ohlp["value"] not in self.metadata["operators"]:
+                    self.metadata["operators"].append(ohlp["value"])
+            elif ohlp["token"] in ["Token.Literal.String.Single",
+                                   "Token.Literal.String.Double",
+                                   "Token.Literal.String.Backtick",
+                                   "Token.Literal.String.Doc"]:
+                if ohlp["value"] not in self.metadata["strings"]:
+                    self.metadata["strings"].append(ohlp["value"])
+            elif ohlp["token"] == "Token.Name.Variable":
+                if ohlp["value"] not in self.metadata["variables"]:
+                    self.metadata["variables"].append(ohlp["value"])
+
+            position += 1


### PR DESCRIPTION
**Describe the change**
Adds a ScanPhp scanner that uses Pygments (similar to ScanBatch and ScanVb).

**Describe testing procedures**
Tested locally with a variety of PHP files.

**Sample output**
Adds a new metadata dictionary to scan results, "phpMetadata". 

```
{
  "tokens": [
    "Token.Comment.Preproc",
    "Token.Text",
    "Token.Name.Variable",
    "Token.Operator",
    "Token.Literal.String.Single",
    "Token.Punctuation",
    "Token.Name.Builtin",
    "Token.Other"
  ],
  "builtins": [
    "str_replace"
  ],
  "operators": [
    "=",
    "."
  ],
  "strings": [
    "Ip"
  ],
  "variables": [
    "$U",
    "$f",
    "$q",
    "$p",
    "$z",
    "$b",
    "$r",
    "$D",
    "$u",
    "$L",
    "$w",
    "$B",
    "$V",
    "$i"
  ]
}
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
