### PR TITLE
Add extraction toggle to extract-strelka.bro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to the project will be tracked in this file via the date of change.
 ### Changed
 - strelka_dirstream.py switched from using inotify to directory polling (Josh Liburdi)
 - strelka_dirstream.py supports monitoring multiple directories (Josh Liburdi)
+- extract-strelka.bro will temporarily disable file extraction when the extraction directory reaches a maximum threshold (Josh Liburdi)
 
 ## 2018-11-27
 ### Added


### PR DESCRIPTION
**Describe the change**
This PR changes the behavior of extract-strelka.bro to temporarily disable file extraction if the size of the extraction directory becomes too large (default threshold is >50,000 files). This is to ensure the stability of Bro/Zeek in case of extended network disruptions between NSM sensor(s) and the Strelka cluster.

**Describe testing procedures**
A variation of this change has been tested for 4+ weeks in a large-scale, production Strelka cluster. The Bro/Zeek script behaves exactly as expected (when file count threshold is met, extraction temporarily stops; when file count threshold passes, extraction starts).

**Sample output**

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
