### PR TITLE
Add ZeroMQ reconnection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2018-12-12
+### Added
+- Options for manually setting ZeroMQ TCP reconnections on the task socket (between broker and workers)
+### Changed
+- "request_port" option renamed to "request_socket_port"
+- "task_port" option renamed to "task_socket_port"
+
 ## 2018-12-10
 ### Changed
 - strelka_dirstream.py switched from using inotify to directory polling (Josh Liburdi)

--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ The "processes" section controls the processes launched by the daemon. The confi
 
 The "network" section controls network connectivity. The configuration options are:
 * "broker": network address of the broker (defaults to 127.0.0.1)
-* "request_port": network port used by clients to send file requests to the broker (defaults to 5558)
-* "task_port": network port used by workers to receive tasks from the broker (defaults to 5559)
+* "request_socket_port": network port used by clients to send file requests to the broker (defaults to 5558)
+* "task_socket_port": network port used by workers to receive tasks from the broker (defaults to 5559)
 
 The "broker" section controls settings related to the broker process. The configuration options are:
 * "poller_timeout": amount of time (in milliseconds) that the broker polls for client requests and worker statuses (defaults to 1000 milliseconds)
@@ -342,6 +342,8 @@ The "broker" section controls settings related to the broker process. The config
 * "prune_delta": delta (in seconds) that must pass since a worker last checked in with the broker before it is considered dead and is pruned (defaults to 10 seconds)
 
 The "workers" section controls settings related to worker processes. The configuration options are:
+* "task_socket_reconnect": amount of time (in milliseconds) that the task socket will attempt to reconnect in the event of TCP disconnection, this will have additional jitter applied (defaults to 100ms plus jitter)
+* "task_socket_reconnect_max": maximum amount of time (in milliseconds) that the task socket will attempt to reconnect in the event of TCP disconnection, this will have additional jitter applied (defaults to 4000ms plus jitter)
 * "poller_timeout": amount of time (in milliseconds) that workers poll for file tasks (defaults to 1000 milliseconds)
 * "file_max": number of files a worker will process before shutting down (defaults to 10000)
 * "time_to_live": amount of time (in minutes) that a worker will run before shutting down (defaults to 30 minutes)

--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -16,8 +16,8 @@ daemon:
 
   network:
     broker: '127.0.0.1'
-    request_port: 5558
-    task_port: 5559
+    request_socket_port: 5558
+    task_socket_port: 5559
 
   broker:
     poller_timeout: 1000
@@ -27,6 +27,8 @@ daemon:
     prune_delta: 10
 
   workers:
+    task_socket_reconnect: 100
+    task_socket_reconnect_max: 4000
     poller_timeout: 1000
     file_max: 10000
     time_to_live: 30
@@ -291,12 +293,6 @@ scan:
         options:
           extract_text: False
           limit: 2000
-    'ScanPhp':
-      - positive:
-          flavors:
-            - 'text/x-php'
-            - 'php_file'
-        priority: 5
     'ScanPe':
       - positive:
           flavors:
@@ -308,6 +304,12 @@ scan:
           flavors:
             - 'application/pgp-keys'
             - 'pgp_file'
+        priority: 5
+    'ScanPhp':
+      - positive:
+          flavors:
+            - 'text/x-php'
+            - 'php_file'
         priority: 5
     'ScanPkcs7':
       - positive:


### PR DESCRIPTION
**Describe the change**
This commit makes two changes:

Ports have been redefined to “socket” ports. This results in no change in functionality, it’s simply a name change that should improve clarity in the configuration options.

Added options for setting ZeroMQ TCP reconnections on the task socket. This can help reduce network noise from the workers when the connection between them and the broker is disrupted.

**Describe testing procedures**
This has been tested for 4+ weeks in a large-scale production cluster, no observable issues in performance.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
