### PR TITLE
Add EOF error handling to bzip2 scanner

### DIFF
--- a/server/scanners/scan_bzip2.py
+++ b/server/scanners/scan_bzip2.py
@@ -24,5 +24,7 @@ class ScanBzip2(objects.StrelkaScanner):
                                                    source=self.scanner_name)
                     self.children.append(child_fo)
 
+                except EOFError:
+                    file_object.flags.append(f"{self.scanner_name}::eof_error")
                 except OSError:
                     file_object.flags.append(f"{self.scanner_name}::os_error")


### PR DESCRIPTION
This PR adds EOF error handling to the bzip2 scanner.

**Describe the change**
Append a flag to bzip2 files if the scanner encounters an end of file error.

**Describe testing procedures**
This was tested on truncated bzip2 files.

**Sample output**
N/A -- this causes no change to the structure of Strelka's output.

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
