### PR TITLE
Bump pyyaml version to resolve CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (p
 python-keystoneclient==3.18.0
 python-magic==0.4.15
 python-swiftclient==3.6.0
-pyyaml==3.13
+pyyaml>=4.2b1
 pyzmq==17.1.2
 rarfile==3.0
 requests==2.21.0


### PR DESCRIPTION
This commit resolves CVE-2017-18342 in pyyaml. Thanks GitHub alerts!

**Describe the change**
Bumped the version of pyyaml from 3.13, which is vulnerable to CVE-2017-18342, to 4.2b1.

**Describe testing procedures**
Loaded up a Strelka server using 4.2b1 -- did not see any issues in loading configuration files.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
