### PR TITLE
added method to archive files with strelka_dirstream.py 

### DIFF
--- a/etc/dirstream/dirstream.yml
+++ b/etc/dirstream/dirstream.yml
@@ -17,8 +17,8 @@ dirstream:
         meta_separator: "S^E^P"
         file_mtime_delta: 5
         delete_files: False
-        archive_files: False
-        archive_directory: "/samples/archive/"
+        move_files: False
+        move_directory: "/samples/processed/"
       network:
         broker: "127.0.0.1:5558"
         timeout: 10

--- a/etc/dirstream/dirstream.yml
+++ b/etc/dirstream/dirstream.yml
@@ -17,6 +17,8 @@ dirstream:
         meta_separator: "S^E^P"
         file_mtime_delta: 5
         delete_files: False
+        archive_files: False
+        archive_directory: "/samples/archive/"
       network:
         broker: "127.0.0.1:5558"
         timeout: 10

--- a/strelka_dirstream.py
+++ b/strelka_dirstream.py
@@ -42,9 +42,9 @@ class DirWorker(multiprocessing.Process):
             last modified before it is sent to the cluster. Defaults to 5 seconds.
         delete_files: Boolean that determines if files should be deleted after
             they are sent to the cluster. Defaults to False.
-        archive_files: Boolean that determines if files should be archived after
+        move_files: Boolean that determines if files should be moved after
             they are sent to the cluster. Defaults to False.
-        archive_directory: Directory to move files to once they are scanned.
+        move_directory: Directory to move files to once they are scanned.
             Defaults to None.
         broker: Network address plus network port of the broker.
             Defaults to "127.0.0.1:5558".
@@ -75,8 +75,8 @@ class DirWorker(multiprocessing.Process):
         self.meta_separator = directory_cfg.get("meta_separator", "S^E^P")
         self.file_mtime_delta = directory_cfg.get("file_mtime_delta", 5)
         self.delete_files = directory_cfg.get("delete_files", False)
-        self.archive_files = directory_cfg.get("archive_files", False)
-        self.archive_directory = directory_cfg.get("archive_directory", None)
+        self.move_files = directory_cfg.get("move_files", False)
+        self.move_directory = directory_cfg.get("move_directory", None)
         self.broker = network_cfg.get("broker", "127.0.0.1:5558")
         self.timeout = network_cfg.get("timeout", 10)
         self.use_green = network_cfg.get("use_green", True)
@@ -114,8 +114,8 @@ class DirWorker(multiprocessing.Process):
                                 self.send_file(path)
                                 if self.delete_files:
                                     self.delete_file(path)
-                                if self.archive_files:
-                                    self.archive_file(path)
+                                if self.move_files:
+                                    self.move_file(path)
                 logging.debug(f"{self.name}: sent {self.sent} files"
                               f" from {self.directory}")
                 self.sent = 0
@@ -141,14 +141,14 @@ class DirWorker(multiprocessing.Process):
             logging.error(f"{self.name}: failed to delete"
                           f" file {path} (PermissionError)")
 
-    def archive_file(self, path):
+    def move_file(self, path):
         """Archives files."""
         try:
-            os.rename(src=path, dst=f"{self.archive_directory}/{path.split('/')[-1]}")
+            os.rename(src=path, dst=f"{self.move_directory}/{path.split('/')[-1]}")
 
         except OSError:
             logging.error(f"{self.name}: failed to move"
-                          f" file {path} dest {self.archive_directory}/{path.split('/')[-1]} (OSError)")
+                          f" file {path} dest {self.move_directory}/{path.split('/')[-1]} (OSError)")
         except PermissionError:
             logging.error(f"{self.name}: failed to move"
                           f" file {path} (PermissionError)")

--- a/strelka_dirstream.py
+++ b/strelka_dirstream.py
@@ -142,7 +142,7 @@ class DirWorker(multiprocessing.Process):
                           f" file {path} (PermissionError)")
 
     def move_file(self, path):
-        """moves files."""
+        """Moves files."""
         try:
             os.rename(src=path, dst=f"{self.move_directory}/{path.split('/')[-1]}")
 

--- a/strelka_dirstream.py
+++ b/strelka_dirstream.py
@@ -142,7 +142,7 @@ class DirWorker(multiprocessing.Process):
                           f" file {path} (PermissionError)")
 
     def move_file(self, path):
-        """Archives files."""
+        """moves files."""
         try:
             os.rename(src=path, dst=f"{self.move_directory}/{path.split('/')[-1]}")
 


### PR DESCRIPTION
**Describe the change**
With the larger ecosystem of tools in mind, we have a usecase where we may want to archive the files that bro/suricata/NSM would store rather than delete them entirely. This would allow other tools to analyze the files, while preventing strelka_dirstream.py from looping over the same files over and over again. Essentially this was more or less a copy of the `delete_file()` method in strelka_distream.py with a few minor modifications.

**Describe testing procedures**
I tested this on our suricata instance which is file carving and determined that it is indeed working. 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
