### PR TITLE
parsing PE version info

### DIFF
--- a/server/scanners/scan_pe.py
+++ b/server/scanners/scan_pe.py
@@ -179,7 +179,7 @@ class ScanPe(objects.StrelkaScanner):
                         if fileinfo.Key.decode() == "StringFileInfo":
                             for block in fileinfo.StringTable:
                                 for name, value in block.entries.items():
-                                    fixedinfo = {"string-name": name.decode(), "value": value.decode()}
+                                    fixedinfo = {"name": name.decode(), "value": value.decode()}
                                     if fixedinfo not in self.metadata["versionInfo"]:
                                         self.metadata["versionInfo"].append(fixedinfo)
             else:

--- a/server/scanners/scan_pe.py
+++ b/server/scanners/scan_pe.py
@@ -172,6 +172,22 @@ class ScanPe(objects.StrelkaScanner):
                 else:
                     file_object.flags.append(f"{self.scanner_name}::empty_signature")
 
+            if hasattr(pe, "FileInfo"):
+                self.metadata.setdefault("versionInfo", {})
+                for l in pe.FileInfo:
+                    if not isinstance(l, list):
+                        l = [l]
+                    for i in l:
+                        if i.Key.decode() == "StringFileInfo":
+                            for j in i.StringTable:
+                                for k, v in j.entries.items():
+                                    info_name = k.decode()
+                                    info_value = v.decode()
+                                    if info_name not in self.metadata["versionInfo"]:
+                                        self.metadata["versionInfo"][info_name] = info_value
+            else:
+                file_object.flags.append(f"{self.scanner_name}::no_version_info")
+
         except IndexError:
             file_object.flags.append(f"{self.scanner_name}::pe_index_error")
         except pefile.PEFormatError:

--- a/server/scanners/scan_pe.py
+++ b/server/scanners/scan_pe.py
@@ -173,18 +173,15 @@ class ScanPe(objects.StrelkaScanner):
                     file_object.flags.append(f"{self.scanner_name}::empty_signature")
 
             if hasattr(pe, "FileInfo"):
-                self.metadata.setdefault("versionInfo", {})
-                for l in pe.FileInfo:
-                    if not isinstance(l, list):
-                        l = [l]
-                    for i in l:
-                        if i.Key.decode() == "StringFileInfo":
-                            for j in i.StringTable:
-                                for k, v in j.entries.items():
-                                    info_name = k.decode()
-                                    info_value = v.decode()
-                                    if info_name not in self.metadata["versionInfo"]:
-                                        self.metadata["versionInfo"][info_name] = info_value
+                self.metadata.setdefault("versionInfo", [])
+                for structure in pe.FileInfo:
+                    for fileinfo in structure:
+                        if fileinfo.Key.decode() == "StringFileInfo":
+                            for block in fileinfo.StringTable:
+                                for name, value in block.entries.items():
+                                    fixedinfo = {"string-name": name.decode(), "value": value.decode()}
+                                    if fixedinfo not in self.metadata["versionInfo"]:
+                                        self.metadata["versionInfo"].append(fixedinfo)
             else:
                 file_object.flags.append(f"{self.scanner_name}::no_version_info")
 


### PR DESCRIPTION
**Describe the change**
Added PE version info to ScanPe scanner

I wasn't sure about adding the "no_version_info" flag since it's relatively common, but that would be easy to remove.

**Describe testing procedures**
Unit test script coming in a second pull request

**Sample output**
This adds a "version_info" key to the scanner.metadata output
```
"version_info": {
    "CompanyName": "Google Inc.",
    "FileDescription": "Google Update Setup",
    "FileVersion": "1.3.33.23",
    "InternalName": "Google Update Setup",
    "LegalCopyright": "Copyright 2007-2010 Google Inc.",
    "OriginalFilename": "GoogleUpdateSetup.exe",
    "ProductName": "Google Update",
    "ProductVersion": "1.3.33.23",
    "LanguageId": "en"
}
```

This can be used to build Kibana visualizations like below
![image](https://user-images.githubusercontent.com/15183688/51763113-e7540980-208e-11e9-98fd-08436d589964.png)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
