### PR TITLE
Better identification of email files during tasting

### DIFF
--- a/etc/strelka/taste/taste.yara
+++ b/etc/strelka/taste/taste.yara
@@ -282,9 +282,15 @@ rule email_file
     strings:
         $a = "\x0aReceived:"
         $b = "\x0AReturn-Path:"
+        $c = "\x0aMessage-ID:"
+        $d = "\x0aReply-To:"
+        $e = "\x0aX-Mailer:"
     condition:
         $a in (0..2048) or
-        $b in (0..2048)
+        $b in (0..2048) or
+        $c in (0..2048) or
+        $d in (0..2048) or
+        $e in (0..2048)
 }
 
 rule tnef_file


### PR DESCRIPTION
**Describe the change**
The email tasting rule wasn't identifying my email messages because it was only looking for two specific headers, which mine didn't have.  I added a few more email-specific headers: Message-ID, Reply-To and X-Mailer.

**Describe testing procedures**
Submitted new email samples and verified they were properly identified.  Sorry, can't share them in public.

**Sample output**
No output changes 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [na ] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
