### PR TITLE
Provide a worker only script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     license="Apache 2.0",
     packages=find_packages(),
     data_files=[("/etc/strelka", ["etc/strelka/strelka.yml", "etc/strelka/pylogging.ini", "etc/strelka/taste/taste.yara", "etc/dirstream/dirstream.yml"])],
-    scripts=["strelka.py", "strelka_dirstream.py", "strelka_user_client.py", "generate_curve_certificates.py", "validate_yara.py"],
+    scripts=["strelka.py", "strelka_dirstream.py", "strelka_user_client.py", "generate_curve_certificates.py", "validate_yara.py", "strelka_standalone.py"],
     zip_safe=False
 )

--- a/strelka_standalone.py
+++ b/strelka_standalone.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from server import objects
+from server import distribution
+from shared import conf
+import sys
+
+CONF_PATH = "etc/strelka/strelka.yml"
+
+def main():
+    if len(sys.argv) != 2 :
+        print("usage: {} filepath".format(sys.argv[0]))
+        sys.exit()
+    config = conf.parse_yaml(path = CONF_PATH, section = "scan")
+    filepath = sys.argv[1]
+    if not os.path.isfile(filepath):
+        print("argument is not a filepath")
+        sys.exit()
+    with open(filepath, 'rb') as f:
+        data = f.read()
+        file_object = objects.StrelkaFile(data = data,
+                filename = os.path.basename(filepath),
+                source="Standalone",
+                external_flavors= [],
+                external_metadata=[])
+        scan_result = {"results": []}
+        distribution.distribute(file_object, scan_result)
+        print(scan_result)
+
+

--- a/strelka_standalone.py
+++ b/strelka_standalone.py
@@ -4,6 +4,8 @@ from server import objects
 from server import distribution
 from shared import conf
 import sys
+import os
+import json
 
 CONF_PATH = "etc/strelka/strelka.yml"
 
@@ -25,6 +27,9 @@ def main():
                 external_metadata=[])
         scan_result = {"results": []}
         distribution.distribute(file_object, scan_result)
-        print(scan_result)
+        print(json.dumps(scan_result))
+
+if __name__ == "__main__":
+    main()
 
 


### PR DESCRIPTION
This script allows to run a worker and get the output without having to set up a broker or a client.
It allowed me test strelka out more easily, and could also be used to run some tests.

Another key difference is that it prints the results instead of appending them to the logs.

It is very simplistic, and could use a better conf management or more options for the output, but it was enough for my needs. Maybe somebody else could make use of it.