### PR TITLE
Expanded ScanZip functionality to unzip password-protected archives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanX509 | Collects metadata from x509 and CRL files | "type" -- string that determines the type of x509 certificate being scanned (no default, assigned as either "der" or "pem" depending on flavor) |
 | ScanXml | Log metadata and extract files from XML files | "extract_tags" -- list of XML tags that will have their text extracted as child files (defaults to empty list)<br>"metadata_tags" -- list of XML tags that will have their text logged as metadata (defaults to empty list) |
 | ScanYara | Scans files with YARA rules | "location" -- location of the YARA rules file or directory (defaults to "/etc/yara/")<br>"metadata_identifiers" -- list of YARA rule metadata identifiers (e.g. "Author") that should be logged as metadata (defaults to empty list) |
-| ScanZip | Extracts files from zip archives | "limit" -- maximum number of files to extract (defaults to 1000) |
+| ScanZip | Extracts files from zip archives | "limit" -- maximum number of files to extract (defaults to 1000)<br>"password_file" -- location of passwords file for zip archives (defaults to etc/strelka/passwords.txt)|
 
 ## Use Cases
 Below are some select use cases that show the value Strelka can add to a threat detection tech stack. Keep in mind that these results are parsed in real time without post-processing and are typically correlated with other detection/response tools (e.g. Bro, Volatility, etc.). The file metadata shown below was derived from files found in [VirusShare](https://virusshare.com/) torrent no. 323 and from a test file in the [MaliciousMacroBot (MMBot) repository](https://github.com/egaus/MaliciousMacroBot).

--- a/etc/strelka/passwords.txt
+++ b/etc/strelka/passwords.txt
@@ -1,0 +1,8 @@
+infected
+
+password
+abc123
+list
+the
+passwords
+here

--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -439,3 +439,4 @@ scan:
         priority: 5
         options:
           limit: 1000
+          password_file: 'etc/strelka/passwords.txt'

--- a/server/scanners/scan_zip.py
+++ b/server/scanners/scan_zip.py
@@ -45,6 +45,7 @@ class ScanZip(objects.StrelkaScanner):
                                 break
 
                             try:
+                                child_file = None
                                 zinfo = zip_file_.getinfo(name)
 
                                 if zinfo.flag_bits & 0x1 and self.rainbow_table: # File is encrypted
@@ -64,17 +65,18 @@ class ScanZip(objects.StrelkaScanner):
                                 else:
                                     child_file = zip_file_.read(name)
 
-                                child_filename = f"{self.scanner_name}::{name}"
-                                child_fo = objects.StrelkaFile(data=child_file,
-                                                               filename=child_filename,
-                                                               depth=file_object.depth + 1,
-                                                               parent_uid=file_object.uid,
-                                                               root_uid=file_object.root_uid,
-                                                               parent_hash=file_object.hash,
-                                                               root_hash=file_object.root_hash,
-                                                               source=self.scanner_name)
-                                self.children.append(child_fo)
-                                self.metadata["total"]["extracted"] += 1
+                                if child_file is not None:
+                                    child_filename = f"{self.scanner_name}::{name}"
+                                    child_fo = objects.StrelkaFile(data=child_file,
+                                                                filename=child_filename,
+                                                                depth=file_object.depth + 1,
+                                                                parent_uid=file_object.uid,
+                                                                root_uid=file_object.root_uid,
+                                                                parent_hash=file_object.hash,
+                                                                root_hash=file_object.root_hash,
+                                                                source=self.scanner_name)
+                                    self.children.append(child_fo)
+                                    self.metadata["total"]["extracted"] += 1
 
                             except NotImplementedError:
                                 file_object.flags.append(f"{self.scanner_name}::unsupported_compression")


### PR DESCRIPTION
**Describe the change**
Added functionality that allows ScanZip to open password-protected zip archives. The user places possible passwords in a text file that is read by ScanZip only if it encounters a password-protected archive. Note that this list of passwords is NOT protected in any way - it is simply a list of "traditional" passwords that are used for protecting malicious files from unintended execution.

**Describe testing procedures**
I tested this by un-zipping password-protected archives.

**Sample output**
N/A

**Checklist**
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of and tested my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
