### PR TITLE
Add recursive functionality to dirstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ The configuration options are:
 * "file_mtime_delta": delta (in seconds) that must pass since a file was last modified before it is sent to the cluster (defaults to 5 seconds)
 * "delete_files": boolean that determines if files should be deleted after they are sent to the cluster (defaults to False)
 * "move_files": boolean that determines if files should be moved to a different directory after being processed. move_directory must be specified for this to work (defaults to False)
-* "move_directory": directory that files are moved to once processed (Defaults to None)
+* "move_directory": directory that files are moved to once processed (defaults to None)
 * "broker": network address and network port of the broker (defaults to "127.0.0.1:5558")
 * "timeout": amount of time (in seconds) to wait for a file to be successfully sent to the broker (defaults to 10)
 * "use_green": boolean that determines if PyZMQ green should be used (this can increase performance at the risk of message loss, defaults to True)

--- a/README.md
+++ b/README.md
@@ -479,10 +479,13 @@ The "processes" section controls the processes launched by the utility. The conf
 The "workers" section controls directory settings and network settings for each worker that sends files to the Strelka cluster. This section is a list; adding multiple directory/network settings makes it so multiple directories can be monitored at once.
 The configuration options are:
 * "directory": directory that files are sent from (defaults to None)
+* "recursive": boolean that enables/disables recursively scanning for files defined in "directory" (defaults to False)
 * "source": application that writes files to the directory, used to control metadata parsing functionality (defaults to None)
 * "meta_separator": unique string used to separate pieces of metadata in a filename, used to parse metadata and send it along with the file to the cluster (defaults to "S^E^P")
 * "file_mtime_delta": delta (in seconds) that must pass since a file was last modified before it is sent to the cluster (defaults to 5 seconds)
 * "delete_files": boolean that determines if files should be deleted after they are sent to the cluster (defaults to False)
+* "move_files": boolean that determines if files should be moved to a different directory after being processed. move_directory must be specified for this to work (defaults to False)
+* "move_directory": directory that files are moved to once processed (Defaults to None)
 * "broker": network address and network port of the broker (defaults to "127.0.0.1:5558")
 * "timeout": amount of time (in seconds) to wait for a file to be successfully sent to the broker (defaults to 10)
 * "use_green": boolean that determines if PyZMQ green should be used (this can increase performance at the risk of message loss, defaults to True)

--- a/etc/dirstream/dirstream.yml
+++ b/etc/dirstream/dirstream.yml
@@ -13,6 +13,7 @@ dirstream:
   workers:
     - directory:
         directory: "/samples/"
+        recursive: True
         source: null
         meta_separator: "S^E^P"
         file_mtime_delta: 5

--- a/etc/dirstream/dirstream.yml
+++ b/etc/dirstream/dirstream.yml
@@ -13,7 +13,7 @@ dirstream:
   workers:
     - directory:
         directory: "/samples/"
-        recursive: False.
+        recursive: False
         source: null
         meta_separator: "S^E^P"
         file_mtime_delta: 5

--- a/etc/dirstream/dirstream.yml
+++ b/etc/dirstream/dirstream.yml
@@ -13,7 +13,7 @@ dirstream:
   workers:
     - directory:
         directory: "/samples/"
-        recursive: True
+        recursive: False.
         source: null
         meta_separator: "S^E^P"
         file_mtime_delta: 5

--- a/strelka_dirstream.py
+++ b/strelka_dirstream.py
@@ -112,7 +112,7 @@ class DirWorker(multiprocessing.Process):
                 if self.recursive:
                     iglobpath = f"{self.directory}/**/*"
                 globbed_paths = glob.iglob(pathname=iglobpath, recursive=self.recursive)
-                for (entry) in enumerate(globbed_paths):
+                for _, entry in enumerate(globbed_paths):
                     if os.path.isfile(entry):
                         file_mtime = os.stat(path=entry).st_mtime
                         mtime_delta = current_time - file_mtime

--- a/strelka_dirstream.py
+++ b/strelka_dirstream.py
@@ -112,7 +112,7 @@ class DirWorker(multiprocessing.Process):
                 if self.recursive:
                     iglobpath = f"{self.directory}/**/*"
                 globbed_paths = glob.iglob(pathname=iglobpath, recursive=self.recursive)
-                for (idx, entry) in enumerate(globbed_paths):
+                for (entry) in enumerate(globbed_paths):
                     if os.path.isfile(entry):
                         file_mtime = os.stat(path=entry).st_mtime
                         mtime_delta = current_time - file_mtime

--- a/strelka_dirstream.py
+++ b/strelka_dirstream.py
@@ -124,7 +124,7 @@ class DirWorker(multiprocessing.Process):
                                 self.move_file(entry)
                             logging.debug(f"{self.name}: Sent file {entry}")
                 if self.sent != 0:
-                    logging.debug(f"{self.name}: Total files sent {self.sent}"
+                    logging.debug(f"{self.name}: Total files sent: {self.sent}"
                                   f" from {self.directory}")
                 self.sent = 0
                 time.sleep(1)


### PR DESCRIPTION
**Describe the change**
Modified the `run()` function while loop to allow for sending files recursively from directories nested below `self.directory`. This option is specified in `etc/dirstream/dirstream.yml`. I also migrated away from using `os.scandir()` to use `glob.iglob()` instead for building the file paths. Lastly, I added some logic at the end of the loop to silence debug logging if `self.sent = 0` 

**Describe testing procedures**
Invoked the following command on our IDS server that is archiving files:
`python3 strelka_dirstream.py -d -c etc/dirstream/dirstream.yml`

Tested this with the following `dirstream.yml` configurations: 

(Recursive: False)
```
dirstream:
  processes:
    shutdown_timeout: 10

  workers:
    - directory:
        directory: "/tmp/samples/"
        recursive: False
        source: null
        meta_separator: "S^E^P"
        file_mtime_delta: 10
        delete_files: False
        move_files: True
        move_directory: "/tmp/processed"
      network:
        broker: "myserver:5558"
        timeout: 10
        use_green: True
        broker_public_key: null
        client_secret_key: null

```
(Recursive: True)
```
dirstream:
  processes:
    shutdown_timeout: 10

  workers:
    - directory:
        directory: "/tmp/samples/"
        recursive: True
        source: null
        meta_separator: "S^E^P"
        file_mtime_delta: 10
        delete_files: False
        move_files: True
        move_directory: "/tmp/processed"
      network:
        broker: "myserver:5558"
        timeout: 10
        use_green: True
        broker_public_key: null
        client_secret_key: null

```



**Sample output**
added debug output: 
`2019-02-05 16:25:22 DEBUG    DirWorker-1: Sent file /somepath/files/2019-02-05/myfile.doc`
modified debug output:
`2019-02-05 19:23:33 DEBUG    DirWorker-1: Total files sent: 3 from  /somepath/files/2019-02-05/`



**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
