### PR TITLE
Add “beautified” to ScanJavascript

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -729,7 +729,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanHeader | Collects file header | "length" -- number of header characters to log as metadata (defaults to 50) |
 | ScanHtml | Collects metadata and extracts embedded files from HTML files | "parser" -- sets the HTML parser used during scanning (defaults to "html.parser") |
 | ScanJarManifest | Collects metadata from JAR manifest files | N/A |
-| ScanJavascript | Collects metadata from Javascript files | "beautify" -- deobfuscates JavaScript before parsing (defaults to True) |
+| ScanJavascript | Collects metadata from Javascript files | "beautify" -- beautifies JavaScript before parsing (defaults to True) |
 | ScanJpeg | Extracts data embedded in JPEG files | N/A |
 | ScanJson | Collects keys from JSON files | N/A |
 | ScanLibarchive | Extracts files from libarchive-compatible archives. | "limit" -- maximum number of files to extract (defaults to 1000) |


### PR DESCRIPTION
This PR resolves #20

**Describe the change**
Adds new metadata field "beautified" to ScanJavascript -- this field describes whether the scanned JS was successfully beautified. If JS was not beautified, then it is parsed as is. 

**Describe testing procedures**
Tested with files that pass the beautification process. No deviations from the default strelka.yaml were necessary.

**Sample output**
```
      "javascriptMetadata": {
        "beautified": true
      }
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
