### PR TITLE
Base64pescanner

### DIFF
--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -442,3 +442,8 @@ scan:
         options:
           limit: 1000
           password_file: 'etc/strelka/passwords.txt'
+    'ScanBase64Pe':
+      - positive:
+          flavors:
+            - 'base64pe_file'
+        priority: 5

--- a/etc/strelka/taste/taste.yara
+++ b/etc/strelka/taste/taste.yara
@@ -359,6 +359,26 @@ rule mz_file
         uint16(0) == 0x5A4D
 }
 
+rule base64pe_file 
+{
+    meta:
+        description = "base64 encoded PE binary"
+        type = "executable"
+    strings:
+        $header01 = "TVqQAAMAAAAEAAAA"
+        $header02 = "TVpQAAIAAAAEAA8A"
+        $header03 = "TVoAAAAAAAAAAAAA"
+        $header04 = "TVpBUlVIieVIgewg"
+        $header05 = "TVqAAAEAAAAEABAA"
+        $header06 = "TVroAAAAAFtSRVWJ"
+        $header07 = "TVqQAAMABAAAAAAA"
+        $header08 = "TVpBUlVIieVIgewgAAAA"
+        $header09 = "kJCQkE1aQVJVSInlSIHsIAAAA"
+        $thisprogram = "pcyBwcm9ncm"
+    condition:
+        any of them
+}
+
 // Image Files
 
 rule bmp_file

--- a/server/scanners/scan_base64_pe.py
+++ b/server/scanners/scan_base64_pe.py
@@ -1,0 +1,38 @@
+import base64
+import binascii
+import io
+import re
+
+from server import objects
+
+
+class ScanBase64Pe(objects.StrelkaScanner):
+    """Decode base64 encoded PE files."""
+    def scan(self, file_object, options):
+        Base64RegEx = re.compile('TV(oAAA|pBUl|pQAA|qAAA|qQAA|roAA)[A-Za-z0-9/+]{248,}[\=]{0,2}')
+        UrlSafeRegEx = re.compile('TV(oAAA|pBUl|pQAA|qAAA|qQAA|roAA)[A-Za-z0-9_-]{248,}[\=]{0,2}')
+        base64pe_string = Base64RegEx.search(str(file_object.data))
+        if base64pe_string:
+            try:
+                decoded_file = base64.b64decode(base64pe_string.group(0))        
+            except binascii.Error:
+                file_object.flags.append(f"{self.scanner_name}::binascii_error_{object_id}")
+        urlsafe_string = UrlSafeRegEx.search(str(file_object.data))
+        if urlsafe_string:
+            try:
+                decoded_file = base64.urlsafe_b64decode(urlsafe_string.group(0))
+            except binascii.Error:
+                file_object.flags.append(f"{self.scanner_name}::binascii_error_{object_id}")
+        if decoded_file:
+            decoded_size = len(decoded_file)
+            self.metadata["decodedSize"] = decoded_size
+            child_filename = f"{self.scanner_name}::size_{decoded_size}"
+            child_fo = objects.StrelkaFile(data=decoded_file,
+                                           filename=child_filename,
+                                           depth=file_object.depth + 1,
+                                           parent_uid=file_object.uid,
+                                           root_uid=file_object.root_uid,
+                                           parent_hash=file_object.hash,
+                                           root_hash=file_object.root_hash,
+                                           source=self.scanner_name)
+            self.children.append(child_fo)


### PR DESCRIPTION
Added a scanner (scan_base64_pe.py) and the corresponding Yara signature (taste.yara) and mapping (strelka.yml) to detect base64-encoded Windows PE executable files, decode them, and resubmit the decoded file for additional scanning.

This is a port of the detection and decoding logic used in https://github.com/pmelson/narc for this same purpose.