### PR TITLE
Updated email tasting rules because headers are case insensitive

### DIFF
--- a/etc/strelka/taste/taste.yara
+++ b/etc/strelka/taste/taste.yara
@@ -280,11 +280,11 @@ rule email_file
     meta:
         type = "email"
     strings:
-        $a = "\x0aReceived:"
-        $b = "\x0AReturn-Path:"
-        $c = "\x0aMessage-ID:"
-        $d = "\x0aReply-To:"
-        $e = "\x0aX-Mailer:"
+        $a = "\x0aReceived:" nocase fullword
+        $b = "\x0AReturn-Path:" nocase fullword
+        $c = "\x0aMessage-ID:" nocase fullword
+        $d = "\x0aReply-To:" nocase fullword
+        $e = "\x0aX-Mailer:" nocase fullword
     condition:
         $a in (0..2048) or
         $b in (0..2048) or


### PR DESCRIPTION
**Describe the change**
Email headers are case-insensitive, but the tasting rule was written as case-sensitive.  This just corrects that, and adds the "fullword" qualifier as an additional check that it's matching correctly.

**Describe testing procedures**
I ran it these in strelka with email messages that didn't match the case in the rules, and they worked.

**Sample output**
No changes 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [na] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
