### PR TITLE
Added option to allow system time vs UTC on log output. UTC default.

### DIFF
--- a/etc/strelka/strelka.yml
+++ b/etc/strelka/strelka.yml
@@ -36,6 +36,7 @@ daemon:
     log_directory: '/var/log/strelka/'
     log_field_case: 'camel'
     log_bundle_events: True
+    log_timestamp_utc: True
 
   logrotate:
     directory: '/var/log/strelka/'

--- a/server/lib.py
+++ b/server/lib.py
@@ -594,9 +594,9 @@ class Worker(multiprocessing.Process):
                        "results": []}
         distribution.distribute(file_object, scan_result)
         if self.log_timestamp_utc:
-            scan_start_time = datetime.utcnow()
+            scan_finish_time = datetime.utcnow()
         else:
-            scan_start_time = datetime.now()
+            scan_finish_time = datetime.now()
         scan_finish_time_iso = scan_finish_time.isoformat(timespec="seconds")
         scan_result["finishTime"] = scan_finish_time_iso
         scan_elapsed_time = (scan_finish_time - scan_start_time).total_seconds()

--- a/server/lib.py
+++ b/server/lib.py
@@ -433,6 +433,10 @@ class Worker(multiprocessing.Process):
     def log_bundle_events(self):
         return self.workers_cfg.get("log_bundle_events", True)
 
+    @property
+    def log_timestamp_utc(self):
+        return self.workers_cfg.get("log_timestamp_utc", True)
+
     def run(self):
         """Defines main worker process.
 
@@ -577,7 +581,10 @@ class Worker(multiprocessing.Process):
             file_task: File task sent by the broker.
         """
         file_object = objects.protobuf_to_file_object(file_task)
-        scan_start_time = datetime.utcnow()
+        if self.log_timestamp_utc:
+            scan_start_time = datetime.utcnow()
+        else:
+            scan_start_time = datetime.now()
         scan_start_time_iso = scan_start_time.isoformat(timespec="seconds")
         scan_result = {"startTime": scan_start_time_iso,
                        "finishTime": None,
@@ -586,7 +593,10 @@ class Worker(multiprocessing.Process):
                        "worker": self.identity.decode(),
                        "results": []}
         distribution.distribute(file_object, scan_result)
-        scan_finish_time = datetime.utcnow()
+        if self.log_timestamp_utc:
+            scan_start_time = datetime.utcnow()
+        else:
+            scan_start_time = datetime.now()
         scan_finish_time_iso = scan_finish_time.isoformat(timespec="seconds")
         scan_result["finishTime"] = scan_finish_time_iso
         scan_elapsed_time = (scan_finish_time - scan_start_time).total_seconds()


### PR DESCRIPTION
**Describe the change**
This allows the option to output logs in UTC or the system time on the server. 

Modified server/lib.py to grab log_timestamp_utc variable from strelka.yml. datetime adjusted based on variable (datetime.utcnow vs datetime.now).

Added strelka.yml with log_timestamp_utc variable with "True" as default.

**Describe testing procedures**
Tested changes on a CentOS 7 VM. Left "True" default, logs came in as UTC. Modified log_timestamp_utc to False, restarted Strelka, logs came in as local system time.

**Sample output**
UTC:
{"startTime": "2019-03-18T21:57:10", "finishTime": "2019-03-18T21:57:22", "elapsedTime": 11.958862, "server":

System Time:
{"startTime": "2019-03-18T15:58:28", "finishTime": "2019-03-18T15:58:39", "elapsedTime": 11.037415, "server":

**Checklist**
- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of and tested my code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
