### PR TITLE
Added option to set Time Zone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG YARA_VERSION=3.8.1
 ARG YARA_PYTHON_VERSION=3.8.1
+ARG TIMEZONE=UTC
 
 # Copy Strelka files
 COPY . /opt/strelka/
@@ -15,8 +16,8 @@ COPY . /opt/strelka/
 RUN apt-get -qq update && \
 # Install optional packages and set time zone
     apt-get install -y software-properties-common apt-utils locales tzdata && \
-    echo "UTC" > /etc/timezone && \
-    ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "$TIMEZONE" > /etc/timezone && \
+    ln -fs /usr/share/zoneinfo/$TIMEZONE /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
     apt-get install --no-install-recommends -qq \
 # Install build packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ COPY . /opt/strelka/
 # Update packages
 RUN apt-get -qq update && \
     apt-get install --no-install-recommends -qq \
+# Install optional packages and set time zone
+    apt-get install -y software-properties-common apt-utils locales tzdata && \
+    echo "UTC" > /etc/timezone && \
+    ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata && \
 # Install build packages
     automake \
     build-essential \
@@ -37,14 +42,9 @@ RUN apt-get -qq update && \
     tesseract-ocr \
     unrar \
     upx \
-    jq
-# Install optional packages and set time zone
-RUN apt-get install -y software-properties-common apt-utils locales tzdata \
-    && echo "UTC" > /etc/timezone \
-    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
-    && dpkg-reconfigure -f noninteractive tzdata
+    jq && \
 # Install Python packages
-RUN  pip3 install -r /opt/strelka/requirements.txt && \
+    pip3 install -r /opt/strelka/requirements.txt && \
 # Install YARA
     cd /tmp/ && \
     curl -OL https://github.com/VirusTotal/yara/archive/v$YARA_VERSION.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ COPY . /opt/strelka/
 
 # Update packages
 RUN apt-get -qq update && \
-    apt-get install --no-install-recommends -qq \
 # Install optional packages and set time zone
     apt-get install -y software-properties-common apt-utils locales tzdata && \
     echo "UTC" > /etc/timezone && \
     ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
+    apt-get install --no-install-recommends -qq \
 # Install build packages
     automake \
     build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:18.04
 
 LABEL maintainer "Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 ARG YARA_VERSION=3.8.1
 ARG YARA_PYTHON_VERSION=3.8.1
 
@@ -35,9 +37,14 @@ RUN apt-get -qq update && \
     tesseract-ocr \
     unrar \
     upx \
-    jq && \
+    jq
+# Install optional packages and set time zone
+RUN apt-get install -y software-properties-common apt-utils locales tzdata \
+    && echo "UTC" > /etc/timezone \
+    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata
 # Install Python packages
-    pip3 install -r /opt/strelka/requirements.txt && \
+RUN  pip3 install -r /opt/strelka/requirements.txt && \
 # Install YARA
     cd /tmp/ && \
     curl -OL https://github.com/VirusTotal/yara/archive/v$YARA_VERSION.tar.gz && \


### PR DESCRIPTION
**Describe the change**
Modified DockerFile to allow the option to set the timezone (default UTC). Needed to add "ENV DEBIAN_FRONTEND=noninteractive" variable to make the install of tzdata package non-interactive. Needed to add necessary packages to modify timezone.

Time Zones are set using the usual Continent/Region format

**Describe testing procedures**

Tested with "UTC" "zoneinfo/UTC" Then with "America/Denver" "zoneinfo/America/Denver"

**Sample output**

# Install optional packages and set time zone
RUN apt-get install -y software-properties-common apt-utils locales tzdata \
    && echo "UTC" > /etc/timezone \
    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
    && dpkg-reconfigure -f noninteractive tzdata

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
