### PR TITLE
Switch pyopenssl to private repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pyjsparser==2.5.2
 pylzma==0.5.0
 protobuf==3.6.1
 pygments==2.3.1
-pyopenssl==18.0.0
+git+https://github.com/jshlbrd/pyopenssl.git
 python-docx==0.8.10
 git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (package installed as 'entropy')
 python-keystoneclient==3.18.0


### PR DESCRIPTION
**Describe the change**
Switched from pyopenssl version 18 to a forked version of the package -- “get_certificates” doesn’t exist in the main repository :/

**Describe testing procedures**
Validated using Wireshark 64-bit EXE as a sample (https://2.na.dl.wireshark.org/win64/Wireshark-win64-3.0.1.exe)

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
