### PR TITLE
Fix ScanDocx bugs

### DIFF
--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -10,6 +10,7 @@ import importlib
 import logging.config
 import math
 import os
+import re
 import string
 import sys
 import time

--- a/src/python/strelka/scanners/scan_docx.py
+++ b/src/python/strelka/scanners/scan_docx.py
@@ -23,15 +23,15 @@ class ScanDocx(strelka.Scanner):
             self.event['comments'] = docx_doc.core_properties.comments
             self.event['content_status'] = docx_doc.core_properties.content_status
             if docx_doc.core_properties.created is not None:
-                self.event['created'] = docx_doc.core_properties.created.isoformat()
+                self.event['created'] = int(docx_doc.core_properties.created.strftime('%s'))
             self.event['identifier'] = docx_doc.core_properties.identifier
             self.event['keywords'] = docx_doc.core_properties.keywords
             self.event['language'] = docx_doc.core_properties.language
             self.event['last_modified_by'] = docx_doc.core_properties.last_modified_by
             if docx_doc.core_properties.last_printed is not None:
-                self.event['last_printed'] = docx_doc.core_properties.last_printed.isoformat()
+                self.event['last_printed'] = int(docx_doc.core_properties.last_printed.strftime('%s'))
             if docx_doc.core_properties.modified is not None:
-                self.event['modified'] = docx_doc.core_properties.modified.isoformat()
+                self.event['modified'] = int(docx_doc.core_properties.modified.strftime('%s'))
             self.event['revision'] = docx_doc.core_properties.revision
             self.event['subject'] = docx_doc.core_properties.subject
             self.event['title'] = docx_doc.core_properties.title
@@ -44,9 +44,10 @@ class ScanDocx(strelka.Scanner):
                 )
 
                 for paragraph in docx_doc.paragraphs:
+                    text = f'{paragraph.text}\n'
                     self.upload_to_coordinator(
                         extract_file.pointer,
-                        paragraph.text,
+                        text,
                         expire_at,
                     )
 


### PR DESCRIPTION
**Describe the change**
ScanDocx had two bugs:
* Timestamps were not converted to Unix / epoch during transition from ZeroMQ to gRPC
* Extracted body text was missing newline characters

In fixing the previous two bugs, a third bug was found in bin/strelka-backend:
* ‘re’ was not imported

**Describe testing procedures**
Wrote a debug scanner called 'ScanWrite' (which writes files to disk) to validate that ScanDocx was incorrectly extracting document body text. Upon fixing it, used the same scanner to valdiate that the body text was correctly extracted.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

```json
{
  "author": "Joshua.Liburdi",
  "created": 1559319600,
  "elapsed": 0.009578,
  "last_modified_by": "Joshua.Liburdi",
  "modified": 1559351520,
  "revision": 4
}
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
