### PR TITLE
Reformat JSON Events

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -29,8 +29,8 @@ type server struct{
 
 type request struct {
         Attributes  *strelka.Attributes     `json:"attributes,omitempty"`
-        Id          string                  `json:"id,omitempty"`
         Client      string                  `json:"client,omitempty"`
+        Id          string                  `json:"id,omitempty"`
         Source      string                  `json:"source,omitempty"`
         Time        int64                   `json:"time,omitempty"`
 }
@@ -94,10 +94,10 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
         }
 
         r := request{
-                Id:incomingRequest.Id,
-                Client:incomingRequest.Client,
-                Source:incomingRequest.Source,
                 Attributes:incomingAttributes,
+                Client:incomingRequest.Client,
+                Id:incomingRequest.Id,
+                Source:incomingRequest.Source,
                 Time:time.Now().Unix(),
         }
 

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -28,10 +28,11 @@ type server struct{
 }
 
 type request struct {
+        Attributes  *strelka.Attributes     `json:"attributes,omitempty"`
         Id          string                  `json:"id,omitempty"`
         Client      string                  `json:"client,omitempty"`
         Source      string                  `json:"source,omitempty"`
-        Attributes  *strelka.Attributes     `json:"attributes,omitempty"`
+        Time        int64                   `json:"time,omitempty"`
 }
 
 func (s *server) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
@@ -97,6 +98,7 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
                 Client:incomingRequest.Client,
                 Source:incomingRequest.Source,
                 Attributes:incomingAttributes,
+                Time:time.Now().Unix(),
         }
 
         for {
@@ -110,7 +112,6 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
                 }
 
                 m := make(map[string]interface{})
-                m["time"] = time.Now().Unix()
                 m["request"] = r
                 if err := json.Unmarshal([]byte(lpop), &m); err != nil{
                         return err

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -159,15 +159,12 @@ class Backend(object):
                         'depth': file.depth,
                         'name': file.name,
                         'flavors': file.flavors,
-                        'scanner_list': [s.get('name')
-                                         for s in scanner_list],
+                        'scanners': [s.get('name') for s in scanner_list],
                         'size': len(data),
                         'source': file.source,
                         'tree': tree_dict,
                     }
-                    event = {
-                        **{'file': file_dict},
-                    }
+                    scan = {}
 
                     for scanner in scanner_list:
                         try:
@@ -180,7 +177,7 @@ class Backend(object):
                                 self.scanner_cache[und_name] = attr
                             options = scanner.get('options', {})
                             plugin = self.scanner_cache[und_name]
-                            (f, e) = plugin.scan_wrapper(
+                            (f, s) = plugin.scan_wrapper(
                                 data,
                                 file,
                                 options,
@@ -188,13 +185,18 @@ class Backend(object):
                             )
                             files.extend(f)
 
-                            event = {
-                                **event,
-                                **e,
+                            scan = {
+                                **scan,
+                                **s,
                             }
 
                         except ModuleNotFoundError:
                             logging.exception(f'scanner {name} not found')
+
+                    event = {
+                        **{'file': file_dict},
+                        **{'scan': scan},
+                    }
 
                     p.rpush(f'event:{root_id}', strelka.format_event(event))
                     p.expireat(f'event:{root_id}', expire_at)

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -83,7 +83,7 @@ class Scanner(object):
     def __init__(self, backend_cfg, coordinator):
         """Inits scanner with scanner name and metadata key."""
         self.name = self.__class__.__name__
-        self.key = inflection.underscore(self.name)
+        self.key = inflection.underscore(self.name.replace('Scan', ''))
         self.scanner_timeout = backend_cfg.get('limits').get('scanner')
         self.coordinator = coordinator
         self.init()


### PR DESCRIPTION
**Describe the change**
This PR alters the JSON events output from the backend. The following changes were made:
* scan_* is now nested under scan: {} ( e.g. scan_hash: {} is now scan: { hash:{} } )
* “time” (request time) is now “request.time” (e.g. request: {“time”: 0} )
* “file.scanners_list” is now “file.scanners”

These changes were made in pursuit of a cleaner and more organized JSON event. 

**Describe testing procedures**
Standard system testing was performed, no outstanding issues identified. 

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**scan dictionary changes:**
```json
  "scan": {
    "entropy": {
      "elapsed": 4.7e-05,
      "entropy": 2.0598225579753513
    },
    "hash": {
      "elapsed": 6e-05,
      "md5": "AAA",
      "sha1": "BBB",
      "sha256": "CCC",
      "ssdeep": "DDD"
    },
    "header": {
      "elapsed": 2.7e-05,
      "header": "�ò�\u0002\u0000\u0004\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000��\u0000\u0000\u0001\u0000\u0000\u0000"
    },
    "yara": {
      "elapsed": 9.8e-05,
      "flags": [
        "compiling_error"
      ]
    }
  }
```

**request.time change:**
```json
  "request": {
    "attributes": {
      "filename": "AAA"
    },
    "id": "b12e252e-149d-4d06-8fa5-ebb3e98d2e22",
    "client": "go-fileshot",
    "source": "BBB",
    "time": 1561408373
  },
```

**file.scanners change**
```json
  "file": {
    "depth": 1,
    "flavors": {
      "mime": [
        "text/plain"
      ],
      "yara": [
        "javascript_file"
      ]
    },
    "name": "script_28",
    "scanners": [
      "ScanEntropy",
      "ScanHash",
      "ScanHeader",
      "ScanJavascript",
      "ScanYara"
    ],
    "size": 55,
    "source": "ScanHtml",
    "tree": {
      "node": "1e947878-7f6c-4772-99db-ce75cfcef57d",
      "parent": "8a7ccfdc-b7f8-4a6e-8add-c79fe805e312"
    }
  },
```


**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
