### PR TITLE
Fix ScanPdf f-string bug

### DIFF
--- a/src/python/strelka/scanners/scan_pdf.py
+++ b/src/python/strelka/scanners/scan_pdf.py
@@ -80,18 +80,18 @@ class ScanPdf(strelka.Scanner):
                                         extracted_objects.add(object_id)
 
                                 except TypeError:
-                                    self.flags.append('type_error_{object_id}')
+                                    self.flags.append(f'type_error_{object_id}')
                                 except struct.error:
-                                    self.flags.append('struct_error_{object_id}')
+                                    self.flags.append(f'struct_error_{object_id}')
 
                         except ValueError:
-                            self.flags.append('value_error_{object_id}')
+                            self.flags.append(f'value_error_{object_id}')
                         except pdftypes.PDFObjectNotFound:
-                            self.flags.append('object_not_found_{object_id}')
+                            self.flags.append(f'object_not_found_{object_id}')
                         except pdftypes.PDFNotImplementedError:
-                            self.flags.append('not_implemented_error_{object_id}')
+                            self.flags.append(f'not_implemented_error_{object_id}')
                         except psparser.PSSyntaxError:
-                            self.flags.append('ps_syntax_error_{object_id}')
+                            self.flags.append(f'ps_syntax_error_{object_id}')
 
                 if extract_text:
                     rsrcmgr = pdfinterp.PDFResourceManager(caching=True)


### PR DESCRIPTION
**Describe the change**
This commit fixes a bug in some ScanPdf flags — some reference the PDF file’s object ID and need to be f-strings.

**Describe testing procedures**
Standard system testing was performed using sample PDF files, no outstanding issues identified.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
