### PR TITLE
Fix ScanElf Dictionary Issues

### DIFF
--- a/src/python/strelka/scanners/scan_elf.py
+++ b/src/python/strelka/scanners/scan_elf.py
@@ -12,6 +12,7 @@ class ScanElf(strelka.Scanner):
             'relocations': len(elf.relocations),
             'sections': elf.header.numberof_sections,
             'segments': elf.header.numberof_segments,
+            'symbols': len(elf.symbols),
         }
 
         self.event['entrypoint'] = elf.entrypoint
@@ -57,10 +58,10 @@ class ScanElf(strelka.Scanner):
             }
 
             if relo.has_section:
-                row['symbol']: relo.section.name
+                row['section'] = relo.section.name
 
             if relo.has_symbol:
-                row['symbol']: relo.symbol.name
+                row['symbol'] = relo.symbol.name
 
             if elf.header.machine_type == ELF.ARCH.x86_64:
                 row['type'] = str(ELF.RELOCATION_X86_64(relo.type)).split('.')[1]
@@ -78,6 +79,7 @@ class ScanElf(strelka.Scanner):
         self.event['sections'] = []
         for sec in elf.sections:
             self.event['sections'].append({
+                'alignment': sec.alignment,
                 'entropy': sec.entropy,
                 'flags': [str(f).split('.')[1] for f in sec.flags_list],
                 'name': sec.name,


### PR DESCRIPTION
**Describe the change**
During a review of ScanMacho, multiple issues were found in ScanElf — relocation symbol and section names were not written correctly, symbol count was missing from the total, and alignment was missing from sections.

**Describe testing procedures**
Standard system testing was performed using sample Elf files.

**Sample output**
```json
  "total": {
    "relocations": 78,
    "sections": 29,
    "segments": 8,
    "symbols": 81
  }
```

```json
  {
    "alignment": 1,
    "entropy": 4.290381706873078,
    "name": ".shstrtab",
    "offset": 16152045,
    "size": 255,
    "type": "STRTAB"
  }
```


**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
