### PR TITLE
Add server dial timeout option

### DIFF
--- a/configs/go/fileshot/fileshot.yaml
+++ b/configs/go/fileshot/fileshot.yaml
@@ -1,7 +1,9 @@
 conn:
   server: '127.0.0.1:57314'
   cert: ''
-  timeout: 1m
+  timeout:
+    dial: 5s
+    file: 1m
 throughput:
   concurrency: 8
   chunk: 32768

--- a/configs/go/filestream/filestream.yaml
+++ b/configs/go/filestream/filestream.yaml
@@ -1,7 +1,9 @@
 conn:
   server: '127.0.0.1:57314'
   cert: ''
-  timeout: 1m
+  timeout:
+    dial: 5s
+    file: 1m
 throughput:
   concurrency: 8
   chunk: 32768

--- a/docs/README.md
+++ b/docs/README.md
@@ -229,7 +229,8 @@ For the options below, only one response setting may be configured.
 
 * "conn.server": network address of the frontend server (defaults to 127.0.0.1:57314)
 * "conn.cert": local path to the frontend SSL server certificate (defaults to empty string -- SSL disabled)
-* "conn.timeout": amount of time to wait for an individual file to complete a scan (defaults to 1 minute)
+* "conn.timeout.dial": amount of time to wait for the client to dial the server (defaults to 5 seconds)
+* "conn.timeout.file": amount of time to wait for an individual file to complete a scan (defaults to 1 minute)
 * "conn.concurrency": number of concurrent requests to make (defaults to 8)
 * "files.chunk": size of file chunks that will be sent to the frontend server (defaults to 32768b / 32kb)
 * "files.patterns": list of glob patterns that determine which files will be sent for scanning (defaults to example glob pattern)
@@ -243,7 +244,8 @@ For the options below, only one response setting may be configured.
 
 * "conn.server": network address of the frontend server (defaults to 127.0.0.1:57314)
 * "conn.cert": local path to the frontend SSL server certificate (defaults to empty string -- SSL disabled)
-* "conn.timeout": amount of time to wait for an individual file to complete a scan (defaults to 1 minute)
+* "conn.timeout.dial": amount of time to wait for the client to dial the server (defaults to 5 seconds)
+* "conn.timeout.file": amount of time to wait for an individual file to complete a scan (defaults to 1 minute)
 * "conn.concurrency": number of concurrent requests to make (defaults to 8)
 * "files.chunk": size of file chunks that will be sent to the frontend server (defaults to 32768b / 32kb)
 * "files.patterns": list of glob patterns that determine which files will be sent for scanning (defaults to example glob pattern)

--- a/src/go/cmd/strelka-fileshot/main.go
+++ b/src/go/cmd/strelka-fileshot/main.go
@@ -9,7 +9,6 @@ import (
         "path/filepath"
         "runtime/pprof"
         "sync"
-        "time"
 
         "google.golang.org/grpc"
         "gopkg.in/yaml.v2"
@@ -59,7 +58,7 @@ func main() {
 
         serv := conf.Conn.Server
         auth := rpc.SetAuth(conf.Conn.Cert)
-        ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+        ctx, cancel := context.WithTimeout(context.Background(), conf.Conn.Timeout.Dial)
         defer cancel()
         conn, err := grpc.DialContext(ctx, serv, auth, grpc.WithBlock())
         if err != nil {
@@ -146,7 +145,7 @@ func main() {
                         go func(){
                                 rpc.ScanFile(
                                         frontend,
-                                        conf.Conn.Timeout,
+                                        conf.Conn.Timeout.File,
                                         req,
                                         responses,
                                 )

--- a/src/go/cmd/strelka-filestream/main.go
+++ b/src/go/cmd/strelka-filestream/main.go
@@ -59,7 +59,7 @@ func main() {
 
         serv := conf.Conn.Server
         auth := rpc.SetAuth(conf.Conn.Cert)
-        ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+        ctx, cancel := context.WithTimeout(context.Background(), conf.Conn.Timeout.Dial)
         defer cancel()
         conn, err := grpc.DialContext(ctx, serv, auth, grpc.WithBlock())
         if err != nil {
@@ -148,7 +148,7 @@ func main() {
                         go func(){
                                 rpc.ScanFile(
                                         frontend,
-                                        conf.Conn.Timeout,
+                                        conf.Conn.Timeout.File,
                                         req,
                                         responses,
                                 )
@@ -204,7 +204,7 @@ func main() {
                                 go func(){
                                         rpc.ScanFile(
                                                 frontend,
-                                                conf.Conn.Timeout,
+                                                conf.Conn.Timeout.File,
                                                 req,
                                                 responses,
                                         )

--- a/src/go/pkg/structs/structs.go
+++ b/src/go/pkg/structs/structs.go
@@ -12,7 +12,12 @@ import (
 type ConfConn struct {
         Server          string                      // required
         Cert            string                      // required
-        Timeout         time.Duration               // required
+        Timeout         ConfTimeout                 // required
+}
+
+type ConfTimeout struct {
+        Dial            time.Duration               // required
+        File            time.Duration               // required
 }
 
 type ConfThroughput struct {


### PR DESCRIPTION
**Describe the change**
This PR makes the server dial timeout a configurable option for both Go clients. This is useful for very slow connections.

**Describe testing procedures**
System testing with a local cluster, tested both fileshot and filestream.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
