### PR TITLE
Added new fields to ScanIni

### DIFF
--- a/src/python/strelka/scanners/scan_ini.py
+++ b/src/python/strelka/scanners/scan_ini.py
@@ -4,18 +4,32 @@ from strelka import strelka
 class ScanIni(strelka.Scanner):
     """Parses keys from INI files."""
     def scan(self, data, file, options, expire_at):
+        self.event['comments'] = []
         self.event['keys'] = []
+        self.event['sections'] = []
 
         section = ''
         ini = data.splitlines()
         for key in ini:
+            key = key.strip()
+            if not key:
+                continue
+
             if key.startswith(b'[') and key.endswith(b']'):
                 section = key[1:-1]
+                self.event['sections'].append(section)
+            elif key.startswith(b'#'):
+                self.event['comments'].append(key)
             else:
                 split_key = key.split(b'=')
-                if len(split_key) == 2:
+                if len(split_key) == 1:
                     self.event['keys'].append({
                         'section': section,
-                        'name': split_key[0],
-                        'value': split_key[1],
+                        'value': split_key[0].strip().strip(b'"\'"'),
+                    })
+                elif len(split_key) == 2:
+                    self.event['keys'].append({
+                        'section': section,
+                        'name': split_key[0].strip().strip(b'"\'"'),
+                        'value': split_key[1].strip().strip(b'"\'"'),
                     })


### PR DESCRIPTION
**Describe the change**
This PR adds two new fields to ScanIni, a 'comments' field and 'sections' field. It also improves the parsing for no named keys.

**Describe testing procedures**
System testing with a local cluster and multiple dummy INI files.

**Sample output**
.scan.ini
```json
{
  "comments": [
    "# this is",
    "# a comment!"
  ],
  "elapsed": 0.000162,
  "keys": [
    {
      "name": "Package",
      "section": "testing",
      "value": "foo"
    },
    {
      "name": "Module",
      "section": "testing",
      "value": "bar"
    },
    {
      "name": "test",
      "section": "testing"
    },
    {
      "section": "testing",
      "value": "test2"
    }
  ],
  "sections": [
    "testing"
  ]
}
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
