### PR TITLE
Modify ScanMacho dynamic symbol

### DIFF
--- a/src/python/strelka/scanners/scan_macho.py
+++ b/src/python/strelka/scanners/scan_macho.py
@@ -431,28 +431,24 @@ class ScanMacho(strelka.Scanner):
             }
 
         if binary.has_dynamic_symbol_command:
-            self.event['commands']['dynamic_symbol_command'] = {
+            self.event['commands']['dynamic_symbol'] = {
                 'command': {
-                    'offset': binary.dynamic_symbol_command.command_offset,
-                    'size': binary.dynamic_symbol_command.size,
+                    'offset': binary.dynamic_symbol.command_offset,
+                    'size': binary.dynamic_symbol.size,
                 },
-                'external': {
-                    'reference': {
-                        'symbol_offset': binary.dynamic_symbol_command.external_reference_symbol_offset,
-                        'relocation_offset': binary.dynamic_symbol_command.external_relocation_offset,
+                'offset': {
+                    'symbol': {
+                        'external': binary.dynamic_symbol.external_reference_symbol_offset,
+                        'indirect': binary.dynamic_symbol.indirect_symbol_offset,
                     },
-                },
-                'indirect': {
-                    'symbol_offset': binary.dynamic_symbol_command.indirect_symbol_offset,
-                },
-                'local': {
-                    'relocation_offset': binary.dynamic_symbol_command.local_relocation_offset,
-                },
-                'module': {
-                    'table_offset': binary.dynamic_symbol_command.module_table_offset,
-                },
-                'toc': {
-                    'offset': binary.dynamic_symbol_command.toc_offset,
+                    'relocation': {
+                        'external': binary.dynamic_symbol.external_relocation_offset,
+                        'local': binary.dynamic_symbol.local_relocation_offset,
+                    },
+                    'table': {
+                        'module': binary.dynamic_symbol.module_table_offset,
+                    },
+                    'toc': binary.dynamic_symbol.toc_offset,
                 },
             }
 

--- a/src/python/strelka/scanners/scan_macho.py
+++ b/src/python/strelka/scanners/scan_macho.py
@@ -433,22 +433,22 @@ class ScanMacho(strelka.Scanner):
         if binary.has_dynamic_symbol_command:
             self.event['commands']['dynamic_symbol'] = {
                 'command': {
-                    'offset': binary.dynamic_symbol.command_offset,
-                    'size': binary.dynamic_symbol.size,
+                    'offset': binary.dynamic_symbol_command.command_offset,
+                    'size': binary.dynamic_symbol_command.size,
                 },
                 'offset': {
                     'symbol': {
-                        'external': binary.dynamic_symbol.external_reference_symbol_offset,
-                        'indirect': binary.dynamic_symbol.indirect_symbol_offset,
+                        'external': binary.dynamic_symbol_command.external_reference_symbol_offset,
+                        'indirect': binary.dynamic_symbol_command.indirect_symbol_offset,
                     },
                     'relocation': {
-                        'external': binary.dynamic_symbol.external_relocation_offset,
-                        'local': binary.dynamic_symbol.local_relocation_offset,
+                        'external': binary.dynamic_symbol_command.external_relocation_offset,
+                        'local': binary.dynamic_symbol_command.local_relocation_offset,
                     },
                     'table': {
-                        'module': binary.dynamic_symbol.module_table_offset,
+                        'module': binary.dynamic_symbol_command.module_table_offset,
                     },
-                    'toc': binary.dynamic_symbol.toc_offset,
+                    'toc': binary.dynamic_symbol_command.toc_offset,
                 },
             }
 


### PR DESCRIPTION
**Describe the change**
This commit improves the nesting event structure for the ScanMacho field commands.dynamic_symbol

**Describe testing procedures**
System testing with a local cluster and multiple Mach-O files.

**Sample output**
.scan.macho.commands.dynamic_symbol
```json
{
  "command": {
    "offset": 1684,
    "size": 80
  },
  "offset": {
    "relocation": {
      "external": 0,
      "local": 0
    },
    "symbol": {
      "external": 0,
      "indirect": 72172
    },
    "table": {
      "module": 0
    },
    "toc": 0
  }
}
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
