### PR TITLE
Fix ScanPe header AttributeError

### DIFF
--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -293,7 +293,6 @@ class ScanPe(strelka.Scanner):
         self.event['header'] = {
             'address': {
                 'code': pe.OPTIONAL_HEADER.BaseOfCode,
-                'data': pe.OPTIONAL_HEADER.BaseOfData,
                 'entry_point': pe.OPTIONAL_HEADER.AddressOfEntryPoint,
                 'image': pe.OPTIONAL_HEADER.ImageBase,
             },
@@ -340,6 +339,9 @@ class ScanPe(strelka.Scanner):
                 'subsystem': float(f'{pe.OPTIONAL_HEADER.MajorSubsystemVersion}.{pe.OPTIONAL_HEADER.MinorSubsystemVersion}'),
             },
         }
+
+        if hasattr(pe.OPTIONAL_HEADER, 'BaseOfData'):
+            self.event['header']['address']['data'] = pe.OPTIONAL_HEADER.BaseOfData
 
         for o in CHARACTERISTICS_DLL:
             if pe.OPTIONAL_HEADER.DllCharacteristics & o:


### PR DESCRIPTION
**Describe the change**
Fixes an AttributeError that occurs when an MZ file does not have base of data information.

**Describe testing procedures**
System testing with a local cluster and an MZ file that causes the error.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
