### PR TITLE
Init ScanPlist

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -270,6 +270,21 @@ scanners:
       priority: 5
       options:
         tmp_directory: '/dev/shm/'
+  'ScanPlist':
+    - positive:
+        flavors:
+          - 'bplist_file'
+          - 'plist_file'
+      priority: 5
+      options:
+        keys:
+          - 'KeepAlive'
+          - 'Label'
+          - 'NetworkState'
+          - 'Program'
+          - 'ProgramArguments'
+          - 'RunAtLoad'
+          - 'StartInterval'
   'ScanRar':
     - positive:
         flavors:

--- a/configs/python/backend/taste/taste.yara
+++ b/configs/python/backend/taste/taste.yara
@@ -651,6 +651,18 @@ rule php_file {
         $a at 0
 }
 
+rule plist_file {
+    meta:
+        description =  "Property list (XML)"
+        type = "text"
+    strings:
+        $a = { 3C 3F ( 58 | 78) ( 4D | 6D ) ( 4C | 6C ) 20 76 65 72 73 69 6F 6E 3D } // <?[Xx][Mm][Ll] version=
+        $b = { 3c 21 44 4f 43 54 59 50 45 20 70 6c 69 73 74 } // <!DOCTYPE plist
+    condition:
+        $a at 0 and
+        $b in (0..100)
+}
+
 rule soap_file {
     meta:
         description = "Simple Object Access Protocol"

--- a/docs/README.md
+++ b/docs/README.md
@@ -523,6 +523,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanPgp | Collects metadata from PGP files | N/A |
 | ScanPhp | Collects metadata from PHP files | N/A |
 | ScanPkcs7 | Extracts files from PKCS7 certificate files | N/A |
+| ScanPlist | Collects attributes from binary and XML property list files | "keys" -- list of keys to log (defaults to ['Label']) |
 | ScanRar | Extracts files from RAR archives | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanRpm | Collects metadata and extracts files from RPM files | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/") |
 | ScanRtf | Extracts embedded files from RTF files | "limit" -- maximum number of files to extract (defaults to 1000) |

--- a/src/python/strelka/scanners/scan_plist.py
+++ b/src/python/strelka/scanners/scan_plist.py
@@ -1,0 +1,22 @@
+import plistlib
+
+import inflection
+
+from strelka import strelka
+
+
+class ScanPlist(strelka.Scanner):
+    """Collects metadata from JAR manifest files."""
+    def scan(self, data, file, options, expire_at):
+        keys = options.get('keys', ['Label'])
+
+        plist = plistlib.loads(data)
+
+        self.event['keys'] = []
+        for k, v in plist.items():
+            if k not in self.event['keys']:
+                self.event['keys'].append(k)
+
+            if k in keys:
+                k = inflection.underscore(k)
+                self.event[k] = v


### PR DESCRIPTION
**Describe the change**
This PR adds a property list (plist) scanner, it supports both binary and XML plists and user-defined key logging.

**Describe testing procedures**
System testing with a local cluster and multiple OSX plist files.

**Sample output**
.scan.plist
```json
{
  "elapsed": 0.000195,
  "keys": [
    "Label",
    "ProgramArguments",
    "Sockets",
    "EnableTransactions"
  ],
  "label": "com.openssh.ssh-agent",
  "program_arguments": [
    "/usr/bin/ssh-agent",
    "-l"
  ]
}
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
