### PR TITLE
Remove binary plist from Exiftool

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -90,7 +90,6 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
-          - 'bplist_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
           - 'psd_file'


### PR DESCRIPTION
**Describe the change**
This commit removes binary plist files from Exiftool parsing in the default backend.yaml — this is replaced by ScanPlist.

**Describe testing procedures**
System testing with a local cluster and multiple OSX plist files.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
