### PR TITLE
Add support for decoding embedded hyperlinks

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -12,6 +12,10 @@ tasting:
   mime_db: null
   yara_rules: '/etc/strelka/taste/'
 scanners:
+  'ScanBase64':
+    - positive:
+        filename: '^base64_'
+      priority: 5
   'ScanBatch':
     - positive:
         flavors:

--- a/docs/README.md
+++ b/docs/README.md
@@ -494,7 +494,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 |--------------|---------------------|-----------------|
 | ScanAntiword | Extracts text from MS Word documents | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/") |
 | ScanBatch | Collects metadata from batch script files | N/A |
-| ScanBatch | Decodes base64-encoded files | N/A |
+| ScanBase64 | Decodes base64-encoded files | N/A |
 | ScanBzip2 | Decompresses bzip2 files | N/A |
 | ScanCuckoo | Sends files to a Cuckoo sandbox | "url" -- URL of the Cuckoo sandbox (defaults to None)<br>"priority" -- Cuckoo priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 10)<br>"unique" -- boolean that tells Cuckoo to only analyze samples that have not been analyzed before (defaults to True)<br>"username" -- username used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_USERNAME")<br>"password" -- password used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_PASSWORD") |
 | ScanDocx | Collects metadata and extracts text from docx files | "extract_text" -- boolean that determines if document text should be extracted as a child file (defaults to False) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -494,6 +494,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 |--------------|---------------------|-----------------|
 | ScanAntiword | Extracts text from MS Word documents | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/") |
 | ScanBatch | Collects metadata from batch script files | N/A |
+| ScanBatch | Decodes base64-encoded files | N/A |
 | ScanBzip2 | Decompresses bzip2 files | N/A |
 | ScanCuckoo | Sends files to a Cuckoo sandbox | "url" -- URL of the Cuckoo sandbox (defaults to None)<br>"priority" -- Cuckoo priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 10)<br>"unique" -- boolean that tells Cuckoo to only analyze samples that have not been analyzed before (defaults to True)<br>"username" -- username used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_USERNAME")<br>"password" -- password used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_PASSWORD") |
 | ScanDocx | Collects metadata and extracts text from docx files | "extract_text" -- boolean that determines if document text should be extracted as a child file (defaults to False) |

--- a/src/python/strelka/scanners/scan_base64.py
+++ b/src/python/strelka/scanners/scan_base64.py
@@ -1,0 +1,22 @@
+import base64
+
+from strelka import strelka
+
+
+class ScanBase64(strelka.Scanner):
+    """Decodes base64-encoded file."""
+    def scan(self, data, file, options, expire_at):
+        decoded = base64.b64decode(data)
+
+        extract_file = strelka.File(
+            source=self.name,
+        )
+
+        for c in strelka.chunk_string(decoded):
+            self.upload_to_coordinator(
+                extract_file.pointer,
+                c,
+                expire_at,
+            )
+
+        self.files.append(extract_file)


### PR DESCRIPTION
**Describe the change**
This commit addresses the payload delivery technique described here: https://isc.sans.edu/forums/diary/Interesting+JavaScript+Obfuscation+Example/25020/. This required the addition of ScanBase64.

**Describe testing procedures**
System testing with a local cluster and files that contain the technique described above.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
