### PR TITLE
Improve key-value parsing

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -90,7 +90,6 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
-          - 'bplist_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
           - 'psd_file'

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -56,30 +56,63 @@ scanners:
     - positive:
         flavors:
           - 'application/msword'
-          - 'application/vnd.openxmlformats-officedocument'
-          - 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
-          - 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-          - 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
           - 'olecf_file'
-          - 'ooxml_file'
-          - 'audio/mpeg'
-          - 'mp3_file'
-          - 'mhtml_file'
+      priority: 5
+      options:
+        keys:
+          - 'Author'
+          - 'Characters'
+          - 'Company'
+          - 'CreateDate'
+          - 'LastModifiedBy'
+          - 'Lines'
+          - 'ModifyDate'
+          - 'Pages'
+          - 'Paragraphs'
+          - 'RevisionNumber'
+          - 'Software'
+          - 'Template'
+          - 'Title'
+          - 'TotalEditTime'
+          - 'Words'
+        tmp_directory: '/dev/shm/'
+    - positive:
+        flavors:
           - 'application/pdf'
           - 'pdf_file'
-          - 'text/rtf'
-          - 'rtf_file'
-          - 'wordml_file'
-          - 'application/x-dosexec'
-          - 'mz_file'
-          - 'application/x-object'
-          - 'application/x-executable'
-          - 'application/x-sharedlib'
-          - 'application/x-coredump'
-          - 'elf_file'
+      priority: 5
+      options:
+        keys:
+          - 'Author'
+          - 'CreateDate'
+          - 'Creator'
+          - 'CreatorTool'
+          - 'Linearized'
+          - 'ModifyDate'
+          - 'PageCount'
+          - 'PDFVersion'
+          - 'Producer'
+          - 'Title'
+        tmp_directory: '/dev/shm/'
+    - positive:
+        flavors:
           - 'lnk_file'
-          - 'application/x-mach-binary'
-          - 'macho_file'
+      priority: 5
+      options:
+        keys:
+          - 'CommandLineArguments'
+          - 'Description'
+          - 'FileAttributes'
+          - 'Flags'
+          - 'HotKey'
+          - 'IconFileName'
+          - 'IconIndex'
+          - 'RunWindow'
+          - 'TargetFileSize'
+          - 'WorkingDirectory'
+        tmp_directory: '/dev/shm/'
+    - positive:
+        flavors:
           - 'image/gif'
           - 'gif_file'
           - 'image/jpeg'
@@ -92,15 +125,11 @@ scanners:
           - 'bmp_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
-          - 'psd_file'
-          - 'video/mp4'
-          - 'video/quicktime'
-          - 'video/x-msvideo'
-          - 'avi_file'
-          - 'video/x-ms-wmv'
-          - 'wmv_file'
       priority: 5
       options:
+        keys:
+          - 'ImageHeight'
+          - 'ImageWidth'
         tmp_directory: '/dev/shm/'
   'ScanGif':
     - positive:

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -57,6 +57,7 @@ scanners:
         flavors:
           - 'application/msword'
           - 'olecf_file'
+          - 'application/vnd.ms-excel'
       priority: 5
       options:
         keys:
@@ -176,6 +177,10 @@ scanners:
         flavors:
           - 'jar_manifest_file'
       priority: 5
+      options:
+        headers:
+          - 'Manifest-Version'
+          - 'Created-By'
   'ScanJavascript':
     - negative:
         flavors:

--- a/docs/README.md
+++ b/docs/README.md
@@ -500,7 +500,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanElf | Collects metadata from ELF files | N/A |
 | ScanEmail | Collects metadata and extract files from email messages | N/A |
 | ScanEntropy | Calculates entropy of files | N/A |
-| ScanExiftool | Collects metadata parsed by Exiftool | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/") |
+| ScanExiftool | Collects metadata parsed by Exiftool | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/")<br>"keys" -- list of keys to log (defaults to all) |
 | ScanFalconSandbox | Sends files to an instance of Falcon Sandbox | "server" -- URL of the Falcon Sandbox API inteface <br>"priority" -- Falcon Sandbox priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 60)<br>"envID" -- list of numeric envrionment IDs that tells Falcon Sandbox which sandbox to submit a sample to (defaults to [100])<br>"api_key" -- API key used for authenticating to Falcon Sandbox (defaults to None, optionally read from environment variable "FS_API_KEY")<br>"api_secret" --  API secret key used for authenticating to Falcon Sandbox (defaults to None, optionally read from environment variable "FS_API_SECKEY") |
 | ScanGif | Extracts data embedded in GIF files | N/A |
 | ScanGzip | Decompresses gzip files | N/A
@@ -523,7 +523,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanPgp | Collects metadata from PGP files | N/A |
 | ScanPhp | Collects metadata from PHP files | N/A |
 | ScanPkcs7 | Extracts files from PKCS7 certificate files | N/A |
-| ScanPlist | Collects attributes from binary and XML property list files | "keys" -- list of keys to log (defaults to ['Label']) |
+| ScanPlist | Collects attributes from binary and XML property list files | "keys" -- list of keys to log (defaults to all) |
 | ScanRar | Extracts files from RAR archives | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanRpm | Collects metadata and extracts files from RPM files | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/") |
 | ScanRtf | Extracts embedded files from RTF files | "limit" -- maximum number of files to extract (defaults to 1000) |

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -237,6 +237,7 @@ func main() {
         cd := redis.NewClient(&redis.Options{
                 Addr:       conf.Coordinator.Addr,
                 DB:         conf.Coordinator.DB,
+                PoolSize:   1000,
         })
         if err := cd.Ping().Err(); err != nil {
                 log.Fatalf("failed to connect to coordinator: %v", err)
@@ -245,6 +246,7 @@ func main() {
         gk := redis.NewClient(&redis.Options{
                 Addr:       conf.Gatekeeper.Addr,
                 DB:         conf.Gatekeeper.DB,
+                PoolSize:   1000,
         })
         if err := gk.Ping().Err(); err != nil {
                 log.Fatalf("failed to connect to gatekeeper: %v", err)

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -237,7 +237,6 @@ func main() {
         cd := redis.NewClient(&redis.Options{
                 Addr:       conf.Coordinator.Addr,
                 DB:         conf.Coordinator.DB,
-                PoolSize:   1000,
         })
         if err := cd.Ping().Err(); err != nil {
                 log.Fatalf("failed to connect to coordinator: %v", err)
@@ -246,7 +245,6 @@ func main() {
         gk := redis.NewClient(&redis.Options{
                 Addr:       conf.Gatekeeper.Addr,
                 DB:         conf.Gatekeeper.DB,
-                PoolSize:   1000,
         })
         if err := gk.Ping().Err(); err != nil {
                 log.Fatalf("failed to connect to gatekeeper: %v", err)

--- a/src/python/strelka/scanners/scan_email.py
+++ b/src/python/strelka/scanners/scan_email.py
@@ -6,6 +6,8 @@ from strelka import strelka
 class ScanEmail(strelka.Scanner):
     """Collects metadata and extract files from email messages."""
     def scan(self, data, file, options, expire_at):
+        headers = options.get('headers', [])
+
         self.event['total'] = {'parts': 0, 'extracted': 0}
 
         try:
@@ -13,14 +15,17 @@ class ScanEmail(strelka.Scanner):
                 data.decode('UTF-8', 'replace')
             )
 
-            self.event.setdefault('headers', [])
-            for (key, value) in message.items():
-                normalized_value = strelka.normalize_whitespace(value.strip())
-                header_entry = {'header': key, 'value': normalized_value}
-                if header_entry not in self.event['headers']:
-                    self.event['headers'].append(header_entry)
+            self.event['headers'] = []
+            for (h, v) in message.items():
+                if headers and h not in headers:
+                    continue
 
-            self.event.setdefault('parts', [])
+                self.event['headers'].append({
+                    'header': h,
+                    'value': strelka.normalize_whitespace(v.strip()),
+                })
+
+            self.event['parts'] = []
             for (index, part) in enumerate(message.walk()):
                 self.event['total']['parts'] += 1
                 extract_data = part.get_payload(decode=True)

--- a/src/python/strelka/scanners/scan_email.py
+++ b/src/python/strelka/scanners/scan_email.py
@@ -16,13 +16,13 @@ class ScanEmail(strelka.Scanner):
             )
 
             self.event['headers'] = []
-            for (h, v) in message.items():
+            for h, v in message.items():
                 if headers and h not in headers:
                     continue
 
                 self.event['headers'].append({
                     'header': h,
-                    'value': strelka.normalize_whitespace(v.strip()),
+                    'value': v,
                 })
 
             self.event['parts'] = []

--- a/src/python/strelka/scanners/scan_exiftool.py
+++ b/src/python/strelka/scanners/scan_exiftool.py
@@ -39,7 +39,7 @@ class ScanExiftool(strelka.Scanner):
                         self.event['keys'].append(k)
 
                     if keys and k not in keys:
-                        pass
+                        continue
 
                     k = inflection.underscore(k)
                     if isinstance(v, str):

--- a/src/python/strelka/scanners/scan_exiftool.py
+++ b/src/python/strelka/scanners/scan_exiftool.py
@@ -3,8 +3,6 @@ import json
 import subprocess
 import tempfile
 
-import inflection
-
 from strelka import strelka
 
 
@@ -33,15 +31,12 @@ class ScanExiftool(strelka.Scanner):
 
             if stdout:
                 exiftool_dictionary = json.loads(stdout)[0]
+
                 self.event['keys'] = []
                 for k, v in exiftool_dictionary.items():
-                    if k not in self.event['keys']:
-                        self.event['keys'].append(k)
-
                     if keys and k not in keys:
                         continue
 
-                    k = inflection.underscore(k)
                     if isinstance(v, str):
                         v = v.strip()
                         v = v.strip('\'"')
@@ -51,4 +46,7 @@ class ScanExiftool(strelka.Scanner):
                         except (ValueError, SyntaxError):
                             pass
 
-                    self.event[k] = v
+                    self.event['keys'].append({
+                        'key': k,
+                        'value': strelka.normalize_whitespace(v.strip()),
+                    })

--- a/src/python/strelka/scanners/scan_exiftool.py
+++ b/src/python/strelka/scanners/scan_exiftool.py
@@ -1,6 +1,9 @@
+import ast
 import json
 import subprocess
 import tempfile
+
+import inflection
 
 from strelka import strelka
 
@@ -9,10 +12,13 @@ class ScanExiftool(strelka.Scanner):
     """Collects metadata parsed by Exiftool.
 
     Options:
+        keys: exiftool key values to log in the event.
+            Defaults to all.
         tmp_directory: Location where tempfile writes temporary files.
             Defaults to '/tmp/'.
     """
     def scan(self, data, file, options, expire_at):
+        keys = options.get('keys', [])
         tmp_directory = options.get('tmp_directory', '/tmp/')
 
         with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
@@ -27,10 +33,22 @@ class ScanExiftool(strelka.Scanner):
 
             if stdout:
                 exiftool_dictionary = json.loads(stdout)[0]
-                self.event.setdefault('exiftool', [])
-                for (key, value) in exiftool_dictionary.items():
-                    if isinstance(value, str):
-                        value = value.strip()
-                    exiftool_entry = {'field': key, 'value': value}
-                    if exiftool_entry not in self.event['exiftool']:
-                        self.event['exiftool'].append(exiftool_entry)
+                self.event['keys'] = []
+                for k, v in exiftool_dictionary.items():
+                    if k not in self.event['keys']:
+                        self.event['keys'].append(k)
+
+                    if keys and k not in keys:
+                        pass
+
+                    k = inflection.underscore(k)
+                    if isinstance(v, str):
+                        v = v.strip()
+                        v = v.strip('\'"')
+
+                        try:
+                            v = ast.literal_eval(v)
+                        except (ValueError, SyntaxError):
+                            pass
+
+                    self.event[k] = v

--- a/src/python/strelka/scanners/scan_exiftool.py
+++ b/src/python/strelka/scanners/scan_exiftool.py
@@ -48,5 +48,5 @@ class ScanExiftool(strelka.Scanner):
 
                     self.event['keys'].append({
                         'key': k,
-                        'value': strelka.normalize_whitespace(v.strip()),
+                        'value': v,
                     })

--- a/src/python/strelka/scanners/scan_html.py
+++ b/src/python/strelka/scanners/scan_html.py
@@ -25,7 +25,7 @@ class ScanHtml(strelka.Scanner):
             soup = bs4.BeautifulSoup(data, parser)
 
             if soup.title:
-                self.event['title'] = strelka.normalize_whitespace(soup.title.text)
+                self.event['title'] = soup.title.text
 
             hyperlinks = []
             hyperlinks.extend(soup.find_all('a', href=True))

--- a/src/python/strelka/scanners/scan_jar_manifest.py
+++ b/src/python/strelka/scanners/scan_jar_manifest.py
@@ -1,18 +1,34 @@
+import ast
+
 from strelka import strelka
 
 
 class ScanJarManifest(strelka.Scanner):
     """Collects metadata from JAR manifest files."""
     def scan(self, data, file, options, expire_at):
+        headers = options.get('headers', [])
+
         manifest = b'\n'.join(data.splitlines()).rstrip(b'\n')
         section_strings = manifest.split(b'\n')
-        self.event.setdefault('manifest', [])
+
+        self.event['headers'] = []
         for section in section_strings:
-            split_section = section.replace(b'\n ', b'').split(b': ')
-            if len(split_section) == 2:
-                jar_entry = {
-                    'header': split_section[0],
-                    'value': split_section[1],
-                }
-                if jar_entry not in self.event['manifest']:
-                    self.event['manifest'].append(jar_entry)
+            s = section.replace(b'\n', b'').split(b':')
+            if len(s) == 2:
+                h, v = s[0].strip(), s[1].strip()
+
+                if h not in self.event['headers']:
+                    self.event['headers'].append(h)
+
+                if headers and h not in headers:
+                    continue
+
+                try:
+                    v = ast.literal_eval(v)
+                except (ValueError, SyntaxError):
+                    pass
+
+                self.event['headers'].append({
+                    'header': h,
+                    'value': v,
+                })

--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -307,7 +307,7 @@ class ScanPe(strelka.Scanner):
             'checksum': pe.OPTIONAL_HEADER.CheckSum,
             'machine': {
                 'id': pe.FILE_HEADER.Machine,
-                'type': pefile.MACHINE_TYPE.get(pe.FILE_HEADER.Machine).replace('IMAGE_FILE_', ''),
+                'type': pefile.MACHINE_TYPE.get(pe.FILE_HEADER.Machine).replace('IMAGE_FILE_MACHINE_', ''),
             },
             'magic': {
                 'dos': MAGIC_DOS.get(pe.DOS_HEADER.e_magic, ''),

--- a/src/python/strelka/scanners/scan_plist.py
+++ b/src/python/strelka/scanners/scan_plist.py
@@ -1,6 +1,5 @@
+import ast
 import plistlib
-
-import inflection
 
 from strelka import strelka
 
@@ -19,11 +18,15 @@ class ScanPlist(strelka.Scanner):
 
         self.event['keys'] = []
         for k, v in plist.items():
-            if k not in self.event['keys']:
-                self.event['keys'].append(k)
-
             if keys and k not in keys:
                 continue
 
-            k = inflection.underscore(k)
-            self.event[k] = v
+            try:
+                v = ast.literal_eval(v)
+            except (ValueError, SyntaxError):
+                pass
+
+            self.event['keys'].append({
+                'key': k,
+                'value': v,
+            })

--- a/src/python/strelka/scanners/scan_plist.py
+++ b/src/python/strelka/scanners/scan_plist.py
@@ -12,7 +12,7 @@ class ScanPlist(strelka.Scanner):
             Defaults to all.
     """
     def scan(self, data, file, options, expire_at):
-        keys = options.get('keys', ['Label'])
+        keys = options.get('keys', [])
 
         plist = plistlib.loads(data)
 

--- a/src/python/strelka/scanners/scan_plist.py
+++ b/src/python/strelka/scanners/scan_plist.py
@@ -6,7 +6,12 @@ from strelka import strelka
 
 
 class ScanPlist(strelka.Scanner):
-    """Collects metadata from JAR manifest files."""
+    """Parses keys found in property list files.
+
+    Options:
+        keys: plist key values to log in the event.
+            Defaults to all.
+    """
     def scan(self, data, file, options, expire_at):
         keys = options.get('keys', ['Label'])
 
@@ -17,6 +22,8 @@ class ScanPlist(strelka.Scanner):
             if k not in self.event['keys']:
                 self.event['keys'].append(k)
 
-            if k in keys:
-                k = inflection.underscore(k)
-                self.event[k] = v
+            if keys and k not in keys:
+                pass
+
+            k = inflection.underscore(k)
+            self.event[k] = v

--- a/src/python/strelka/scanners/scan_plist.py
+++ b/src/python/strelka/scanners/scan_plist.py
@@ -23,7 +23,7 @@ class ScanPlist(strelka.Scanner):
                 self.event['keys'].append(k)
 
             if keys and k not in keys:
-                pass
+                continue
 
             k = inflection.underscore(k)
             self.event[k] = v

--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -42,24 +42,24 @@ class ScanYara(strelka.Scanner):
         except (yara.Error, yara.SyntaxError):
             self.flags.append('compiling_error')
 
-        self.event.setdefault('matches', [])
-        self.event.setdefault('metadata', [])
+        self.event['matches'] = []
+        self.event['meta'] = []
 
         try:
             if self.compiled_yara is not None:
                 yara_matches = self.compiled_yara.match(data=data)
                 for match in yara_matches:
                     self.event['matches'].append(match.rule)
-                    if metadata_identifiers and match.meta:
-                        for (key, value) in match.meta.items():
-                            if key in metadata_identifiers:
-                                yara_entry = {
-                                    'rule': match.rule,
-                                    'identifier': key,
-                                    'value': value,
-                                }
-                                if yara_entry not in self.event['metadata']:
-                                    self.event['metadata'].append(yara_entry)
+
+                    for k, v in match.meta.items():
+                        if meta and k not in meta:
+                            continue
+
+                        self.event['meta'].append({
+                            'rule': match.rule,
+                            'identifier': k,
+                            'value': v,
+                        })
 
         except (yara.Error, yara.TimeoutError):
             self.flags.append('scanning_error')

--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -16,8 +16,8 @@ class ScanYara(strelka.Scanner):
     Options:
         location: Location of the YARA rules file or directory.
             Defaults to '/etc/yara/'.
-        metadata_identifiers: List of YARA rule metadata identifiers
-            (e.g. 'Author') that should be logged as metadata.
+        meta: List of YARA rule meta identifiers
+            (e.g. 'Author') that should be logged.
             Defaults to empty list.
     """
     def init(self):
@@ -25,7 +25,7 @@ class ScanYara(strelka.Scanner):
 
     def scan(self, data, file, options, expire_at):
         location = options.get('location', '/etc/yara/')
-        metadata_identifiers = options.get('metadata_identifiers', [])
+        meta = options.get('meta', [])
 
         try:
             if self.compiled_yara is None:


### PR DESCRIPTION
**Describe the change**
This pull request gives administrators more control over which key-value pairs are logged in scanners that support key-value pairs (ScanEmail, ScanExiftool, ScanJarManifest, ScanPe, ScanPlist, ScanYara). This also updates the ScanExiftool default config to less liberally log key-value pairs.

**Describe testing procedures**
System testing with a stage cluster receiving many types of files.

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
