### PR TITLE
Changing page variable to in-memory stream

### DIFF
--- a/src/python/strelka/scanners/scan_pdf.py
+++ b/src/python/strelka/scanners/scan_pdf.py
@@ -109,7 +109,7 @@ class ScanPdf(strelka.Scanner):
                         laparams=la_params,
                     )
                     interpreter = pdfinterp.PDFPageInterpreter(rsrcmgr, device)
-                    for page in pdfpage.PDFPage.get_pages(data, set()):
+                    for page in pdfpage.PDFPage.get_pages(pdf_io, set()):
                         try:
                             interpreter.process_page(page)
 


### PR DESCRIPTION
**Describe the change**
A reference to the "data" variable caused issues with pdfminer while attempting to extract text from a PDF. This error would only occur when the user sets "extract_text" to True from the ScanPdf options in backend.yml. To fix this, we are instead replacing "data" with "pdf_io", an in-memory stream of the data object. This is readable by pdfminer, whereas the data object was not.

**Describe testing procedures**
Change was made on a local instance. No errors were observed after making the change, and the error that appeared previously was removed. Logging was used to examine the output, which displays proper text extraction.

**Sample output**
Text extraction noted in header.header:

`"scan": {
    "entropy": {
      "elapsed": 0.000155,
      "entropy": 4.953766942682617
    },
    "hash": {
      "elapsed": 0.000296,
      "md5": "039f829a06d43589415673da5ec04431",
      "sha1": "05b0afac91db59a9de83a2d8b9886586dd76e383",
      "sha256": "d42488f5ff2444ce075f19c89751ab8f092d9d31c6bae7643b10f3a9550fd5ac",
      "ssdeep": "192:8lsOIwGOp0/KydxQYBfluX/NtVuvpAyO0aAszFVtLuWNg:8lsOIwGdXDubylzaAs1Lucg"
    },
    "header": {
      "elapsed": 0.000124,
      "header": "he pdf995 suite of products - Pdf995, PdfEdit995, "
    },
    "url": {
      "elapsed": 0.003095,
      "urls": [
        "www.pdf995.com",
        "http://www.wired.com/\",whichisnothuman-centereddata.In"
      ]
    },
    "yara": {
      "elapsed": 0.000207,
      "flags": [
        "compiling_error"
      ]
    }
`

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
