### PR TITLE
added password brute forcing for encrypted rar files to ScanRar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -526,7 +526,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanPhp | Collects metadata from PHP files | N/A |
 | ScanPkcs7 | Extracts files from PKCS7 certificate files | N/A |
 | ScanPlist | Collects attributes from binary and XML property list files | "keys" -- list of keys to log (defaults to all) |
-| ScanRar | Extracts files from RAR archives | "limit" -- maximum number of files to extract (defaults to 1000) |
+| ScanRar | Extracts files from RAR archives | "limit" -- maximum number of files to extract (defaults to 1000)<br>"password_file" -- location of passwords file for zip archives (defaults to etc/strelka/passwords.txt) |
 | ScanRpm | Collects metadata and extracts files from RPM files | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/") |
 | ScanRtf | Extracts embedded files from RTF files | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanSelf | Collects metadata from the file's internal attributes | N/A |

--- a/src/python/strelka/scanners/scan_rar.py
+++ b/src/python/strelka/scanners/scan_rar.py
@@ -50,7 +50,7 @@ class ScanRar(strelka.Scanner):
                     rf_info_list = rar_obj.infolist()
                     self.event['total']['files'] = len(rf_info_list)
 
-                    password = 'password'
+                    password = ''
                     for rf_object in rf_info_list:
                         if not rf_object.isdir():
                             if self.event['total']['extracted'] >= file_limit:
@@ -67,11 +67,9 @@ class ScanRar(strelka.Scanner):
                                     if not password:
                                         for pw in self.passwords:
                                             try:
-                                                extract_data = rar_obj.read(rf_object, str(pw))
-                                                if not extract_data.lstrip().startswith(b'Failed'):
-                                                    password = str(pw)
+                                                extract_data = rar_obj.read(rf_object, pw.decode('utf-8'))
+                                                if extract_data:
                                                     break
-
                                             except (RuntimeError, rarfile.BadRarFile):
                                                 pass
                                     else:

--- a/src/python/strelka/scanners/scan_rar.py
+++ b/src/python/strelka/scanners/scan_rar.py
@@ -64,18 +64,24 @@ class ScanRar(strelka.Scanner):
                                 if not file_info.needs_password():
                                     extract_data = rar_obj.read(rf_object)
                                 else:
+                                    if not 'password_protected' in self.flags:
+                                        self.flags.append('password_protected')  
+                                    
                                     if not password:
                                         for pw in self.passwords:
                                             try:
                                                 extract_data = rar_obj.read(rf_object, pw.decode('utf-8'))
                                                 if extract_data:
+                                                    self.event['password'] = pw.decode('utf-8')
                                                     break
                                             except (RuntimeError, rarfile.BadRarFile):
                                                 pass
                                     else:
                                         extract_data = rar_obj.read(rf_object, password)
-                                    
-                                    self.flags.append('password_protected')            
+
+                                    if not extract_data and not 'no_password_match_found' in self.flags:
+                                        self.flags.append('no_password_match_found')
+                                              
 
                                 if extract_data:
                                     extract_file = strelka.File(


### PR DESCRIPTION
Describe the change
Added logic to test extraction of rar files that are password protected via a brute force password list.

Describe testing procedures
Tested parsing of password protected rar files with both rar and rar4 encoding. The rar scanner was able to unrar and extract nested documents.

Sample output
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
