### PR TITLE
handle missing 'MZ' PE file header

### DIFF
--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -211,7 +211,11 @@ VAR_FILE_INFO_CHARS = {
 class ScanPe(strelka.Scanner):
     """Collects metadata from PE files."""
     def scan(self, data, file, options, expire_at):
-        pe = pefile.PE(data=data)
+        try:
+            pe = pefile.PE(data=data)
+        except pefile.PEFormatError:
+            self.flags.append('pe_format_error')
+            return
 
         self.event['total'] = {
             'libraries': 0,


### PR DESCRIPTION
**Describe the change**
The PE parsing library we use expects there to be a 0x4D5A file header.
If the "DOS magic header" is missing then the libary fails out. This
change captures that exception and sets an event flag to indicate an
error occurred. Users who hit this error should review the scanned files
and their yara rules for tasting files.

**Describe testing procedures**
Made changes to scan_pe.py and then configured fileshot to scan 'text/plain' flavored files and verified the output in the strelka log

**Sample output**
```json
{
  "file": {
    "depth": 0,
    "flavors": {
      "mime": [
        "text/plain"
      ]
    },
    "scanners": [
      "ScanEntropy",
      "ScanHash",
      "ScanHeader",
      "ScanPe",
      "ScanUrl",
      "ScanYara"
    ],
    "size": 237,
    "tree": {
      "node": "e9a94ae3-ca3c-40d2-a861-23d713fc7c33"
    }
  },
  "request": {
    "attributes": {
      "filename": "/tmp/fileshot.yaml"
    },
    "client": "go-fileshot",
    "id": "f51960c5-fffb-4288-8525-9fb19f1f0103",
    "source": "c3f0fc7f9be0",
    "time": 1569859181
  },
  "scan": {
    "entropy": {
      "elapsed": 7.5e-05,
      "entropy": 4.456137798827291
    },
    "hash": {
      "elapsed": 0.000107,
      "md5": "abe2d2d712c912c610997cd550945733",
      "sha1": "0d564e345d077c61427a16f24f9a0e14ab108c22",
      "sha256": "47c90f2ffac8996e844bf35e79de87c551f1017268ffc3380fa5af1704665d18",
      "ssdeep": "6:1eAwRwHTk3pkxtvFNQOmiFuQ4piyXBlFurvF/yORm5YARF2EcEWv:1eLwg3pk/FNQ+wnlwNyR5YSoE+v"
    },
    "header": {
      "elapsed": 6.2e-05,
      "header": "conn:\n  server: 'frontend:57314'\n  cert: ''\n  time"
    },
    "pe": {
      "elapsed": 0.000306,
      "flags": [
        "pe_format_error"
      ]
    },
    "url": {
      "elapsed": 0.000346
    },
    "yara": {
      "elapsed": 0.000146,
      "flags": [
        "compiling_error"
      ]
    }
  }
}
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
