### PR TITLE
Exception handling for plist load failure

### DIFF
--- a/src/python/strelka/scanners/scan_plist.py
+++ b/src/python/strelka/scanners/scan_plist.py
@@ -1,5 +1,6 @@
 import ast
 import plistlib
+import xml
 
 from strelka import strelka
 
@@ -14,19 +15,22 @@ class ScanPlist(strelka.Scanner):
     def scan(self, data, file, options, expire_at):
         keys = options.get('keys', [])
 
-        plist = plistlib.loads(data)
+        try:
+            plist = plistlib.loads(data)
 
-        self.event['keys'] = []
-        for k, v in plist.items():
-            if keys and k not in keys:
-                continue
+            self.event['keys'] = []
+            for k, v in plist.items():
+                if keys and k not in keys:
+                    continue
 
-            try:
-                v = ast.literal_eval(v)
-            except (ValueError, SyntaxError):
-                pass
+                try:
+                    v = ast.literal_eval(v)
+                except (ValueError, SyntaxError):
+                    pass
 
-            self.event['keys'].append({
-                'key': k,
-                'value': v,
-            })
+                self.event['keys'].append({
+                    'key': k,
+                    'value': v,
+                })
+        except xml.parsers.expat.ExpatError:
+            self.flags.append('invalid_format')


### PR DESCRIPTION
Seen in invalid XML files, will throw errors on the backend. Attributing exception to a flag.

**Describe the change**
Adding in a try / except for plist loading to solve backend exceptions noted in https://github.com/target/strelka/issues/103.

**Describe testing procedures**
Built and executing fileshot against several hundred plist files, including one invalid plist file.

**Sample output**
```  
 "plist": {
      "elapsed": 0.001473,
      "flags": [
        "invalid_format"
      ]
    }
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
