### PR TITLE
Adding error handling for corrupt documents

### DIFF
--- a/src/python/strelka/scanners/scan_docx.py
+++ b/src/python/strelka/scanners/scan_docx.py
@@ -1,5 +1,6 @@
 import io
 from bs4 import BeautifulSoup
+from zlib import error
 import docx
 import zipfile
 
@@ -88,3 +89,5 @@ class ScanDocx(strelka.Scanner):
                 self.flags.append('value_error')
             except zipfile.BadZipFile:
                 self.flags.append('bad_zip')
+            except error:
+                self.flags.append('bad_doc')


### PR DESCRIPTION
**Describe the change**
This change was implemented as part of researching a fix for the issue identified in https://github.com/target/strelka/issues/121. That issue was opened based on corrupted documents which this scanner should not and will not support - however, additional error handling was implemented to ensure that the throw exception will be caught and saved as a flag.

**Describe testing procedures**
Corrupted .docx files were submitted through the a local cluster from release 0.19.08.27.

**Sample output**
```
 "scan": {
    "docx": {
      "elapsed": 0.00444,
      "flags": [
        "bad_doc"
      ]
    }
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
