### PR TITLE
Updated to reflect change in command structure

### DIFF
--- a/src/go/cmd/strelka-manager/main.go
+++ b/src/go/cmd/strelka-manager/main.go
@@ -37,13 +37,14 @@ func main() {
 		PoolSize:    conf.Coordinator.Pool,
 		ReadTimeout: conf.Coordinator.Read,
 	})
-	if err := cd.Ping().Err(); err != nil {
+	if err := cd.Ping(cd.Context()).Err(); err != nil {
 		log.Fatalf("failed to connect to coordinator: %v", err)
 	}
 
 	// TODO: this should be a goroutine
 	for {
 		zrem, err := cd.ZRemRangeByScore(
+		    cd.Context(),
 			"tasks",
 			"-inf",
 			fmt.Sprintf("(%v", time.Now().Unix()),


### PR DESCRIPTION
**Describe the change**
The [go-redis](https://github.com/go-redis/redis) package [was updated to accept `context.Context` as the first argument for all commands](https://github.com/go-redis/redis/commit/a8cd04089222eb178f2f254acddbdea0b4ce41ea). This update caused an exception in the previous code which did not pass a Context object to several commands. 

Examples of exceptions seen:

```
# github.com/target/strelka/src/go/cmd/strelka-manager

./main.go:40:19: not enough arguments in call to cd.cmdable.Ping
	have ()
	want (context.Context)
./main.go:46:35: not enough arguments in call to cd.cmdable.ZRemRangeByScore
	have (string, string, string)
	want (context.Context, string, string, string)
```

[To fix this issue](https://github.com/go-redis/redis/issues/1333#issuecomment-633171474), all files using go-redis were updated with the appropriate Context objects.

**Describe testing procedures**
Containers were rebuilt, redeployed, with several scanner tests for twenty minutes, allowing backend containers to restart automatically as needed. No additional issues were identified.

**Sample output**
No output changes are expected

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
