### PR TITLE
Capa

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer "Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 ARG YARA_VERSION=3.11.0
 ARG YARA_PYTHON_VERSION=3.11.0
+ARG CAPA_VERSION=1.1.0
 
 # Copy Strelka files
 COPY ./src/python/ /strelka/
@@ -37,6 +38,15 @@ RUN apt-get -qq update && \
     unrar \
     upx \
     jq && \
+# Install FireEye CAPA
+#   - Binary installation, not supported as Python 3 plugin
+#   - Requires binary to be executable
+#   - Vivisect dependency requires available /.viv/ folder.
+    cd /tmp/ && \
+    curl -OL https://github.com/fireeye/capa/releases/download/v$CAPA_VERSION/capa-linux && \
+    chmod +x /tmp/capa-linux && \
+    mkdir /.viv/ && \
+    chmod -R a+rw /.viv && \
 # Install Python packages
     pip3 install -r /strelka/requirements.txt && \
     pip3 install --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com lief && \

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -35,6 +35,15 @@ scanners:
           - 'application/x-bzip2'
           - 'bzip2_file'
       priority: 5
+#  'ScanCapa':
+#    - positive:
+#        flavors:
+#          - 'application/x-dosexec'
+#          - 'mz_file'
+#      priority: 5
+#      options:
+#        tmp_directory: '/dev/shm/'
+#        location: '/etc/capa/'
   'ScanDocx':
     - positive:
         flavors:

--- a/docs/README.md
+++ b/docs/README.md
@@ -527,6 +527,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanBatch | Collects metadata from batch script files | N/A |
 | ScanBase64 | Decodes base64-encoded files | N/A | [Nathan Icart](https://github.com/nateicart)
 | ScanBzip2 | Decompresses bzip2 files | N/A |
+| ScanCapa | Analyzes files with FireEye [capa](https://github.com/fireeye/capa) | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/")<br>"location" -- location of the capa rules file or directory (defaults to "/etc/capa/") |
 | ScanCuckoo | Sends files to a Cuckoo sandbox | "url" -- URL of the Cuckoo sandbox (defaults to None)<br>"priority" -- Cuckoo priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 10)<br>"unique" -- boolean that tells Cuckoo to only analyze samples that have not been analyzed before (defaults to True)<br>"username" -- username used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_USERNAME")<br>"password" -- password used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_PASSWORD") |
 | ScanDocx | Collects metadata and extracts text from docx files | "extract_text" -- boolean that determines if document text should be extracted as a child file (defaults to False) |
 | ScanElf | Collects metadata from ELF files | N/A |

--- a/src/python/strelka/scanners/scan_capa.py
+++ b/src/python/strelka/scanners/scan_capa.py
@@ -1,4 +1,5 @@
 import re
+import os
 import json
 import subprocess
 import tempfile
@@ -20,47 +21,56 @@ class ScanCapa(strelka.Scanner):
         tmp_directory = options.get('tmp_directory', '/tmp/')
         location = options.get('location', '/etc/capa/')
 
-        try:
-            with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
-                tmp_data.write(data)
-                tmp_data.flush()
-
-                try:
-                    (stdout, stderr) = subprocess.Popen(
-                        ['/tmp/capa-linux', tmp_data.name, '-r', location, '-j'],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.DEVNULL
-                    ).communicate()
-                except:
-                    self.flags.append('processing_error')
-
-                if stdout:
-                    # Observed extraneous data in stdout requiring string trimming. Parse out JSON response.
-                    # This can be fixed when CAPA is aviailable as a Python 3 library.
-                    try:
-                        stdout = stdout[stdout.find(b'{'):]
-                        stdout = stdout[:stdout.rfind(b'}')]
-                        stdout += b'}'
-                        capa_json = json.loads(stdout)
-                    except:
-                        self.flags.append('parsing_error')
-
-                    # Sets are used to remove duplicative values
-                    self.event['matches'] = set()
-                    self.event['attack'] = set()
+        # Only run if rules file exists, otherwise return no rules error
+        if len(os.listdir(location)) != 0:
+            try:
+                with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
+                    tmp_data.write(data)
+                    tmp_data.flush()
 
                     try:
-                        for k, v in capa_json['rules'].items():
-                            self.event['matches'].add(k)
-                            if 'att&ck' in v['meta']:
-                                result = re.search(r'^([^:]+)::([^\[)]+)\s\[([^\]]+)\]', v['meta']['att&ck'][0])
-                                self.event['attack'].add(result.group(2))
-                        # For consistency, convert sets to list
-                        self.event['matches'] = list(self.event['matches'])
-                        self.event['attack'] = list(self.event['attack'])
+                        (stdout, stderr) = subprocess.Popen(
+                            ['/tmp/capa-linux', tmp_data.name, '-r', location, '-j'],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.DEVNULL
+                        ).communicate()
                     except:
-                        self.flags.append('collection_error')
-        except:
-            self.flags.append('scan_error')
+                        self.flags.append('error_processing')
+                        return
+
+                    if stdout:
+                        # Observed extraneous data in stdout requiring string trimming. Parse out JSON response.
+                        # This can be fixed when CAPA is aviailable as a Python 3 library.
+                        try:
+                            stdout = stdout[stdout.find(b'{'):]
+                            stdout = stdout[:stdout.rfind(b'}')]
+                            stdout += b'}'
+                            capa_json = json.loads(stdout)
+                        except:
+                            self.flags.append('error_parsing')
+                            return
+
+                        try:
+                            # Sets are used to remove duplicative values
+                            self.event['matches'] = set()
+                            self.event['mitre_techniques'] = set()
+                            self.event['mitre_ids'] = set()
+
+                            for k, v in capa_json['rules'].items():
+                                self.event['matches'].add(k)
+                                if 'att&ck' in v['meta']:
+                                    result = re.search(r'^([^:]+)::([^\[)]+)\s\[([^\]]+)\]', v['meta']['att&ck'][0])
+                                    self.event['mitre_techniques'].add(result.group(2))
+                                    self.event['mitre_ids'].add(result.group(3))
+                            # For consistency, convert sets to list
+                            self.event['matches'] = list(self.event['matches'])
+                            self.event['mitre_techniques'] = list(self.event['mitre_techniques'])
+                            self.event['mitre_ids'] = list(self.event['mitre_ids'])
+                        except:
+                            self.flags.append('error_collection')
+            except:
+                self.flags.append('error_execution')
+        else:
+            self.flags.append('error_norules')
 
 

--- a/src/python/strelka/scanners/scan_capa.py
+++ b/src/python/strelka/scanners/scan_capa.py
@@ -1,0 +1,66 @@
+import re
+import json
+import subprocess
+import tempfile
+
+from strelka import strelka
+
+
+class ScanCapa(strelka.Scanner):
+    """Executes FireEye CAPA with versioned rules and provides known capabilities and MITRE ATT&CK matches.
+
+    Options:
+        tmp_directory: Location where tempfile writes temporary files.
+            Defaults to '/tmp/'.
+        location: Location of the CAPA rules file or directory.
+            Defaults to '/etc/capa/'
+    """
+
+    def scan(self, data, file, options, expire_at):
+        tmp_directory = options.get('tmp_directory', '/tmp/')
+        location = options.get('location', '/etc/capa/')
+
+        try:
+            with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
+                tmp_data.write(data)
+                tmp_data.flush()
+
+                try:
+                    (stdout, stderr) = subprocess.Popen(
+                        ['/tmp/capa-linux', tmp_data.name, '-r', location, '-j'],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL
+                    ).communicate()
+                except:
+                    self.flags.append('processing_error')
+
+                if stdout:
+                    # Observed extraneous data in stdout requiring string trimming. Parse out JSON response.
+                    # This can be fixed when CAPA is aviailable as a Python 3 library.
+                    try:
+                        stdout = stdout[stdout.find(b'{'):]
+                        stdout = stdout[:stdout.rfind(b'}')]
+                        stdout += b'}'
+                        capa_json = json.loads(stdout)
+                    except:
+                        self.flags.append('parsing_error')
+
+                    # Sets are used to remove duplicative values
+                    self.event['matches'] = set()
+                    self.event['attack'] = set()
+
+                    try:
+                        for k, v in capa_json['rules'].items():
+                            self.event['matches'].add(k)
+                            if 'att&ck' in v['meta']:
+                                result = re.search(r'^([^:]+)::([^\[)]+)\s\[([^\]]+)\]', v['meta']['att&ck'][0])
+                                self.event['attack'].add(result.group(2))
+                        # For consistency, convert sets to list
+                        self.event['matches'] = list(self.event['matches'])
+                        self.event['attack'] = list(self.event['attack'])
+                    except:
+                        self.flags.append('collection_error')
+        except:
+            self.flags.append('scan_error')
+
+


### PR DESCRIPTION
**Describe the change**
[FireEye capa](https://github.com/fireeye/capa) scanner developed to scan executables for potential threat functionality / capabilities. This change required the following:

- Update Backend Dockerfile to install FireEye capa. Tool is not supported in Python3, requiring the binary to be installed with additional perfmissions.
- Developed capa scanner
- Updated backend configuration, but disabling capa as it is time consuming. **Enable only knowing that this should be run on specific types of executables or with the understanding that it will take considerable time to run per executable.**

**Describe testing procedures**
Built and tested on the Master branch. No errors thrown.

**Sample output**
```
  "scan": {
    "capa": {
      "elapsed": 9.30723,
      "matches": [
        "accept command line arguments",
        "parse PE header",
        "access PE header",
        "get system information",
        "contain loop",
        "contain a resource (.rsrc) section"
      ],
      "mitre_ids": [
        "T1082",
        "T1129"
      ],
      "mitre_techniques": [
        "Shared Modules",
        "System Information Discovery"
      ]
    },
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
