### PR TITLE
Add FireEye Floss Scanner

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -47,6 +47,12 @@ RUN apt-get -qq update && \
     chmod +x /tmp/capa-linux && \
     mkdir /.viv/ && \
     chmod -R a+rw /.viv && \
+# Install FireEye FLOSS
+#   - Binary installation, not supported as Python 3 plugin
+#   - Requires binary to be executable
+    cd /tmp/ && \
+    curl -OL https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/linux/dist/floss && \
+    chmod +x /tmp/floss && \
 # Install Python packages
     pip3 install -r /strelka/requirements.txt && \
     pip3 install --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com lief && \

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -157,6 +157,15 @@ scanners:
           - 'ImageHeight'
           - 'ImageWidth'
         tmp_directory: '/dev/shm/'
+#  'ScanFloss':
+#    - positive:
+#        flavors:
+#          - 'application/x-dosexec'
+#          - 'mz_file'
+#      priority: 5
+#      options:
+#        tmp_directory: '/dev/shm/'
+#        limit: 100
   'ScanGif':
     - positive:
         flavors:

--- a/docs/README.md
+++ b/docs/README.md
@@ -527,7 +527,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanBatch | Collects metadata from batch script files | N/A |
 | ScanBase64 | Decodes base64-encoded files | N/A | [Nathan Icart](https://github.com/nateicart)
 | ScanBzip2 | Decompresses bzip2 files | N/A |
-| ScanCapa | Analyzes files with FireEye [capa](https://github.com/fireeye/capa) | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/")<br>"location" -- location of the capa rules file or directory (defaults to "/etc/capa/") |
+| ScanCapa | Analyzes executable files with FireEye [capa](https://github.com/fireeye/capa) | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/")<br>"location" -- location of the capa rules file or directory (defaults to "/etc/capa/") |
 | ScanCuckoo | Sends files to a Cuckoo sandbox | "url" -- URL of the Cuckoo sandbox (defaults to None)<br>"priority" -- Cuckoo priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 10)<br>"unique" -- boolean that tells Cuckoo to only analyze samples that have not been analyzed before (defaults to True)<br>"username" -- username used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_USERNAME")<br>"password" -- password used for authenticating to Cuckoo (defaults to None, optionally read from environment variable "CUCKOO_PASSWORD") |
 | ScanDocx | Collects metadata and extracts text from docx files | "extract_text" -- boolean that determines if document text should be extracted as a child file (defaults to False) |
 | ScanElf | Collects metadata from ELF files | N/A |
@@ -536,6 +536,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanEntropy | Calculates entropy of files | N/A |
 | ScanExiftool | Collects metadata parsed by Exiftool | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/")<br>"keys" -- list of keys to log (defaults to all) |
 | ScanFalconSandbox | Sends files to an instance of Falcon Sandbox | "server" -- URL of the Falcon Sandbox API inteface <br>"priority" -- Falcon Sandbox priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 60)<br>"envID" -- list of numeric envrionment IDs that tells Falcon Sandbox which sandbox to submit a sample to (defaults to [100])<br>"api_key" -- API key used for authenticating to Falcon Sandbox (defaults to None, optionally read from environment variable "FS_API_KEY")<br>"api_secret" --  API secret key used for authenticating to Falcon Sandbox (defaults to None, optionally read from environment variable "FS_API_SECKEY") |
+| ScanFloss | Analyzes executable files with FireEye [floss](https://github.com/fireeye/flare-floss) | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/")<br>"limit" -- Maximum amount of strings to collect. (defaults to 100) |
 | ScanGif | Extracts data embedded in GIF files | N/A |
 | ScanGzip | Decompresses gzip files | N/A
 | ScanHash | Calculates file hash values | N/A |

--- a/src/python/strelka/scanners/scan_floss.py
+++ b/src/python/strelka/scanners/scan_floss.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import tempfile
+
+from strelka import strelka
+
+
+class ScanFloss(strelka.Scanner):
+    """Executes FireEye FLOSS.
+
+    Options:
+        tmp_directory: Location where tempfile writes temporary files.
+            Defaults to '/tmp/'.
+        limit: Maximum amount of strings to collect.
+            Defaults to 100.
+    """
+
+    def scan(self, data, file, options, expire_at):
+        tmp_directory = options.get('tmp_directory', '/tmp/')
+        limit = options.get('limit', 100)
+
+        self.event['decoded'] = []
+        self.event['stack'] = []
+
+        try:
+            with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
+                # Write out the sample to a temporary file
+                tmp_data.write(data)
+
+                try:
+                    # Write out floss results to a temporary file for processing
+                    with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_output:
+                        try:
+                            subprocess.Popen(
+                                ['/tmp/floss', '-q', '--no-static-strings', '-o', tmp_output.name, tmp_data.name],
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL
+                            ).communicate()
+                            floss_json = json.load(tmp_output)
+                        except:
+                            self.flags.append('error_processing')
+                            return
+
+                        try:
+                            if floss_json['strings']['decoded_strings']:
+                                self.event['decoded'] = floss_json['strings']['decoded_strings'][:limit]
+                            if floss_json['strings']['stack_strings']:
+                                self.event['stack'] = floss_json['strings']['stack_strings'][:limit]
+                        except:
+                            self.flags.append('error_parsing')
+                            return
+                except:
+                    self.flags.append('error_execution')
+        except:
+            self.flags.append('error_execution')
+
+


### PR DESCRIPTION
**Describe the change**
[FireEye FLOSS](https://github.com/fireeye/flare-floss) scanner developed to scan and collect obfuscated strings from binaries:

This change required the following:

- Update Backend Dockerfile to install FireEye FLOSS binary. Tool is not supported in Python3, requiring the binary to be installed with additional permissions.
- Developed FLOSS scanner
- Updated backend configuration, but disabling FLOSS as it is time consuming. **Enable only knowing that this should be run on specific types of executables or with the understanding that it will take considerable time to run per executable. (Averaging 7-40 seconds)**

**Describe testing procedures**
Built and tested on the Master branch. No new exceptions thrown.

**Sample output**

_Stack Strings_
```
    "floss": {
      "elapsed": 21.127397,
      "stack": [
        "CacheFile",
        "!!!!",
        "Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Setup\\ServiceStartup\\"
      ]
    },
```
_Decoded Strings_
```
    "floss": {
      "decoded": [
        " n;^",
        "Qkkbal",
        "i]Wb",
        "9a&g",
        "MGiI",
        "wn>Jj",
        "#.zf",
        "+o*7"
      ],
      "elapsed": 39.023579
    },
```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
