### PR TITLE
Bug Fix: Redis Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2020-11-20
+### Changed
+- Pinned redis module to version 8 due to bug causing frontend and manager to fail compilation (https://github.com/target/strelka/issues/142) (phutelmyer)
+
 ## 2020-08-13
 ### Added
 - FireEye capa scanner

--- a/build/go/frontend/Dockerfile
+++ b/build/go/frontend/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang AS build
 LABEL maintainer "Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
+ENV GO111MODULE=on
+
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-RUN cd /go/src/github.com/target/strelka/src/go/cmd/strelka-frontend/ && \
-    go get . && \
-    CGO_ENABLED=0 go build -o /tmp/strelka-frontend .
+WORKDIR /go/src/github.com/target/strelka/src/go/
+
+RUN go mod init && cd /go/src/github.com/target/strelka/src/go/cmd/strelka-frontend/ && \
+ CGO_ENABLED=0 go build -o /tmp/strelka-frontend .
 
 FROM alpine
 COPY --from=build /tmp/strelka-frontend /usr/local/bin/strelka-frontend

--- a/build/go/manager/Dockerfile
+++ b/build/go/manager/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang AS build
 LABEL maintainer "Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
+ENV GO111MODULE=on
+
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-RUN cd /go/src/github.com/target/strelka/src/go/cmd/strelka-manager/ && \
-    go get . && \
-    CGO_ENABLED=0 go build -o /tmp/strelka-manager .
+WORKDIR /go/src/github.com/target/strelka/src/go/
+
+RUN go mod init && cd /go/src/github.com/target/strelka/src/go/cmd/strelka-manager/ && \
+ CGO_ENABLED=0 go build -o /tmp/strelka-manager .
 
 FROM alpine
 COPY --from=build /tmp/strelka-manager /usr/local/bin/strelka-manager

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -12,7 +12,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"

--- a/src/go/cmd/strelka-manager/main.go
+++ b/src/go/cmd/strelka-manager/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v8"
 	"gopkg.in/yaml.v2"
 
 	"github.com/target/strelka/src/go/pkg/structs"


### PR DESCRIPTION
**Describe the change**
The dependency `go-redis` for `strelka-frontend` and `strelka-manager` has recently been updated, which caused issues in compilation of the `strelka` cluster (https://github.com/go-redis/redis/issues/1534). A fix has been implemented to use a previous release of `go-redis` (`v8`). While this should act as a fix, it should also be temporary until an alternative solution has been identified or `go-redis` fixes this issue.

Related Issue: https://github.com/target/strelka/issues/142

**Describe testing procedures**
- Destroyed and rebuilt all strelka images to identify additional errors.
- Ran multiple scanners to identify additional errors and review output changes.

**Sample output**
No output changes.

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
