### PR TITLE
Add Option to Disable Strelka Backend Shutdown

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -306,8 +306,8 @@ For the options below, only one response setting may be configured.
 The backend configuration contains two sections: one that controls the backend process and one that controls how scanners are applied to data.
 
 * "logging_cfg": path to the Python logging configuration (defaults to /etc/strelka/logging.yaml)
-* "limits.max_files": number of files the backend will process before shutting down (defaults to 5000)
-* "limits.time_to_live": amount of time (in seconds) that the backend will run before shutting down (defaults to 900 seconds / 15 minutes)
+* "limits.max_files": number of files the backend will process before shutting down (defaults to 5000, specify 0 to disable)
+* "limits.time_to_live": amount of time (in seconds) that the backend will run before shutting down (defaults to 900 seconds / 15 minutes, specify 0 to disable)
 * "limits.max_depth": maximum depth that extracted files will be processed by the backend (defaults to 15)
 * "limits.distribution": amount of time (in seconds) that a single file can be distributed to all scanners (defaults to 600 seconds / 10 minutes)
 * "limits.scanner": amount of time (in seconds) that a scanner can spend scanning a file (defaults to 150 seconds / 1.5 minutes, can be overridden per-scanner)

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -59,10 +59,11 @@ class Backend(object):
         work_expire = work_start + self.limits.get('time_to_live')
 
         while 1:
-            if count >= self.limits.get('max_files'):
-                break
-            if time.time() >= work_expire:
-                break
+            if self.limits.get('max_files') != "0" or self.limits.get('time_to_live') != "0":
+                if count >= self.limits.get('max_files'):
+                    break
+                if time.time() >= work_expire:
+                    break
 
             task = self.coordinator.zpopmin('tasks', count=1)
             if len(task) == 0:

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -59,9 +59,10 @@ class Backend(object):
         work_expire = work_start + self.limits.get('time_to_live')
 
         while 1:
-            if self.limits.get('max_files') != 0 or self.limits.get('time_to_live') != 0:
+            if self.limits.get('max_files') != 0:
                 if count >= self.limits.get('max_files'):
                     break
+            if self.limits.get('time_to_live') != 0:
                 if time.time() >= work_expire:
                     break
 

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -59,7 +59,7 @@ class Backend(object):
         work_expire = work_start + self.limits.get('time_to_live')
 
         while 1:
-            if self.limits.get('max_files') != "0" or self.limits.get('time_to_live') != "0":
+            if self.limits.get('max_files') != 0 or self.limits.get('time_to_live') != 0:
                 if count >= self.limits.get('max_files'):
                     break
                 if time.time() >= work_expire:


### PR DESCRIPTION
**Describe the change**
This change provides the option to prevent `strelka-backend` from shutting itself down after `max_files` or `time_to_live` has been reached.

**Describe testing procedures**
Rebuilt the `strelka-backend` image and tested using a value of `0` for max_files and time_to_live in `backend.yml`


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
