### PR TITLE
Updating images due to dependency issues

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer "Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 ARG YARA_VERSION=3.11.0

--- a/build/python/mmrpc/Dockerfile
+++ b/build/python/mmrpc/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer "Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 # Copy Strelka files


### PR DESCRIPTION
Also: Adding `noninteractive argument` to prevent timezone / prompts

**Describe the change**
Updating Ubuntu image to 20.04 as some dependencies were having issues with the previous Ubuntu image.

**Describe testing procedures**
Implemented changes and tested 12+ scanners in a localized cluster.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
