### PR TITLE
Pinning Cryptography Dependency

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.8.2
 boltons==20.1.0
+cryptography==3.3.2
 esprima==4.0.1
 grpcio==1.27.2
 grpcio-tools==1.27.2

--- a/build/python/mmrpc/requirements.txt
+++ b/build/python/mmrpc/requirements.txt
@@ -1,3 +1,4 @@
+cryptography==3.3.2
 grpcio==1.27.2
 grpcio-tools==1.27.2
 git+https://github.com/egaus/MaliciousMacroBot


### PR DESCRIPTION
Recent versions of cryptography have shown failures in the rust requirements / installations. Pinning for now.

**Describe the change**
Updating backend and mmrpc requirements with a pinned cryptography.

**Describe testing procedures**
Built Strelka locally and within Github Actions

**Sample output**
N/A
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
