### PR TITLE
Add option to move files to processed directory after submission

### DIFF
--- a/build/go/filestream/Dockerfile
+++ b/build/go/filestream/Dockerfile
@@ -14,5 +14,8 @@ RUN go mod init && \
 # Move build, install additional packages, and initialize non-root user
 FROM alpine
 COPY --from=build /tmp/strelka-filestream /usr/local/bin/strelka-filestream
+RUN addgroup -g 939 strelka && \
+    adduser -u 939 -G strelka strelka --disabled-password \
+    -h /etc/strelka --no-create-home strelka
 RUN apk add --no-cache jq
-USER 1001
+USER strelka

--- a/build/go/filestream/Dockerfile
+++ b/build/go/filestream/Dockerfile
@@ -14,8 +14,5 @@ RUN go mod init && \
 # Move build, install additional packages, and initialize non-root user
 FROM alpine
 COPY --from=build /tmp/strelka-filestream /usr/local/bin/strelka-filestream
-RUN addgroup -g 939 strelka && \
-    adduser -u 939 -G strelka strelka --disabled-password \
-    -h /etc/strelka --no-create-home strelka
 RUN apk add --no-cache jq
-USER strelka
+USER 1001

--- a/docs/README.md
+++ b/docs/README.md
@@ -281,6 +281,7 @@ For the options below, only one response setting may be configured.
 * "files.chunk": size of file chunks that will be sent to the frontend server (defaults to 32768b / 32kb)
 * "files.patterns": list of glob patterns that determine which files will be sent for scanning (defaults to example glob pattern)
 * "files.delete": boolean that determines if files should be deleted after being sent for scanning (defaults to false -- does not delete files)
+* "files.processed": directory where files will be moved after being submitted for scanning (defaults to "", and files stay in staging directory)
 * "response.log": location where worker scan results are logged to (defaults to /var/log/strelka/strelka.log)
 * "response.report": frequency at which the frontend reports the number of files processed (no default)
 * "delta": time value that determines how much time must pass since a file was last modified before it is sent for scanning (defaults to 5 seconds)

--- a/src/go/cmd/strelka-filestream/main.go
+++ b/src/go/cmd/strelka-filestream/main.go
@@ -141,6 +141,7 @@ func main() {
 				Chunk:  conf.Throughput.Chunk,
 				Delay:  conf.Throughput.Delay,
 				Delete: conf.Files.Delete,
+				ProcessedDir:   conf.Files.ProcessedDir,
 			}
 
 			sem <- 1
@@ -197,6 +198,7 @@ func main() {
 					Chunk:  conf.Throughput.Chunk,
 					Delay:  conf.Throughput.Delay,
 					Delete: conf.Files.Delete,
+					ProcessedDir:   conf.Files.ProcessedDir,
 				}
 
 				sem <- 1

--- a/src/go/cmd/strelka-filestream/main.go
+++ b/src/go/cmd/strelka-filestream/main.go
@@ -141,7 +141,7 @@ func main() {
 				Chunk:  conf.Throughput.Chunk,
 				Delay:  conf.Throughput.Delay,
 				Delete: conf.Files.Delete,
-				ProcessedDir:   conf.Files.ProcessedDir,
+				Processed:   conf.Files.Processed,
 			}
 
 			sem <- 1
@@ -198,7 +198,7 @@ func main() {
 					Chunk:  conf.Throughput.Chunk,
 					Delay:  conf.Throughput.Delay,
 					Delete: conf.Files.Delete,
-					ProcessedDir:   conf.Files.ProcessedDir,
+					Processed:   conf.Files.Processed,
 				}
 
 				sem <- 1

--- a/src/go/pkg/rpc/rpc.go
+++ b/src/go/pkg/rpc/rpc.go
@@ -128,13 +128,13 @@ func ScanFile(client strelka.FrontendClient, timeout time.Duration, req structs.
 	}
 	if req.Delete {
 		defer os.Remove(req.Attributes.Filename)
-	} else if req.ProcessedDir != "" {
+	} else if req.Processed != "" {
                 defer func() {
                         _, name := filepath.Split(req.Attributes.Filename)
-                        m := filepath.Join(req.ProcessedDir, name)
+                        m := filepath.Join(req.Processed, name)
                         err := os.Rename(req.Attributes.Filename, m)
                         if err != nil {
-                                log.Printf("failed to move file %s to directory %s: %v", name, req.ProcessedDir, err)
+                                log.Printf("failed to move file %s to directory %s: %v", name, req.Processed, err)
                         }
                 }()
         }

--- a/src/go/pkg/structs/structs.go
+++ b/src/go/pkg/structs/structs.go
@@ -30,7 +30,7 @@ type ConfFiles struct {
 	Patterns   []string // required
 	Delete     bool     // optional
 	Gatekeeper bool     // required
-	ProcessedDir string // optional
+	Processed string // optional
 }
 
 type ConfCoordinator struct {
@@ -97,5 +97,5 @@ type ScanFileRequest struct {
 	Chunk      int                 // required
 	Delay      time.Duration       // optional
 	Delete     bool                // optional, only use if files must be deleted!
-	ProcessedDir     string        // optional
+	Processed  string              // optional
 }

--- a/src/go/pkg/structs/structs.go
+++ b/src/go/pkg/structs/structs.go
@@ -30,6 +30,7 @@ type ConfFiles struct {
 	Patterns   []string // required
 	Delete     bool     // optional
 	Gatekeeper bool     // required
+	ProcessedDir string // optional
 }
 
 type ConfCoordinator struct {
@@ -96,4 +97,5 @@ type ScanFileRequest struct {
 	Chunk      int                 // required
 	Delay      time.Duration       // optional
 	Delete     bool                // optional, only use if files must be deleted!
+	ProcessedDir     string        // optional
 }


### PR DESCRIPTION
**Describe the change**
Allows files to be moved to another directory (out of staging) after being submitted for scanning.  This directory can be specified by adding `files.processed` to `filestream.yaml`.  

**Describe testing procedures**
Tested  with:

- `/nsm/strelka/unprocessed` as `files.patterns`
- `/nsm/strelka/staging` as `staging`
- `/nsm/strelka/processed` as `files.processed`

1. `echo "MyTestFileContent" > /nsm/strelka/unprocessed/mytestfile`
2. File is moved by Strelka into `/nsm/strelka/staging`.
3. File is submitted for scanning, then moved to `/nsm/strelka/processed`.

Shout-out to @rwwiv for his help with this,  bc I can't Golang good 😆 .

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
