### PR TITLE
Adding client oneshot Dockerfile

### DIFF
--- a/build/go/oneshot/Dockerfile
+++ b/build/go/oneshot/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang AS build
+LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
+
+# Copy source files and set the working directory
+COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
+WORKDIR /go/src/github.com/target/strelka/src/go/
+
+# Initialize, get, and build go modules and main package
+RUN go mod init && \
+    go mod tidy && \
+    cd /go/src/github.com/target/strelka/src/go/cmd/strelka-oneshot/ && \
+    CGO_ENABLED=0 go build -o /tmp/strelka-oneshot .
+
+# Move build and initialize non-root user
+FROM alpine
+COPY --from=build /tmp/strelka-oneshot /usr/local/bin/strelka-oneshot
+RUN apk add --no-cache jq
+USER 1001

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,8 +145,19 @@ Strelka's core client apps are written in Go and can be run natively on a host o
     cd /opt/strelka/src/go/cmd/strelka-oneshot/
     go build -o strelka-oneshot .
     ```
+   
+#### strelka-oneshot (container)
+1. Clone this repository
+    ```sh
+    git clone https://github.com/target/strelka.git /opt/strelka/
+    ```
 
-
+2. Build the container
+    ```sh
+    cd /opt/strelka/
+    docker build -f build/go/oneshot/Dockerfile -t strelka-oneshot .
+    ```
+   
 #### strelka-filestream (gettable)
 1. Install the binary
     ```sh


### PR DESCRIPTION
**Describe the change**
Strelka oneshot required a `go build` and did not support Docker (unlike `fileshot`). Implemented a Dockerfile.

**Describe testing procedures**
1. Cloned the repository
    ```sh
    git clone https://github.com/target/strelka.git /opt/strelka/
    ```

2. Built the container
    ```sh
    cd /opt/strelka/
    docker build -f build/go/oneshot/Dockerfile -t strelka-oneshot .
    ```

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
