### PR TITLE
Refactoring go Dockerfiles / adding modfiles

### DIFF
--- a/build/go/fileshot/Dockerfile
+++ b/build/go/fileshot/Dockerfile
@@ -1,18 +1,30 @@
+# Strelka Fileshot
+# Client is designed to one-shot upload files and retrieve their results
+# For more information, please see: https://target.github.io/strelka/#/?id=strelka-fileshot
 FROM golang AS build
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 # Copy source files and set the working directory
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-WORKDIR /go/src/github.com/target/strelka/src/go/
+WORKDIR /go/src/github.com/target/strelka/src/go/cmd/strelka-fileshot
 
-# Initialize, get, and build go modules and main package
-RUN go mod init && \
-    go mod tidy && \
-    cd /go/src/github.com/target/strelka/src/go/cmd/strelka-fileshot/ && \
+# Statically compile and output to tmp
+RUN go mod download && \
     CGO_ENABLED=0 go build -o /tmp/strelka-fileshot .
 
-# Move build and initialize non-root user
+# Initialize runtime container
 FROM alpine
+LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
+
+# Copy binary
 COPY --from=build /tmp/strelka-fileshot /usr/local/bin/strelka-fileshot
+
+# Install jq
 RUN apk add --no-cache jq
+
+# Initialize with non-root user
 USER 1001
+
+# Set container entrypoint. This could be set/overridden elsewhere in deployment (e.g. k8s, docker-compose, etc.)
+# Currently overwritten in ./build/docker-compose.yml
+ENTRYPOINT ["strelka-fileshot"]

--- a/build/go/filestream/Dockerfile
+++ b/build/go/filestream/Dockerfile
@@ -1,18 +1,30 @@
+# Strelka Filestream
+# Client is designed to continuously stream files and retrieves their results.
+# For more information, please see: https://target.github.io/strelka/#/?id=strelka-filestream
 FROM golang AS build
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 # Copy source files and set the working directory
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-WORKDIR /go/src/github.com/target/strelka/src/go/
+WORKDIR /go/src/github.com/target/strelka/src/go/cmd/strelka-filestream
 
-# Initialize, get, and build go modules and main package
-RUN go mod init && \
-    go mod tidy && \
-    cd /go/src/github.com/target/strelka/src/go/cmd/strelka-filestream/ && \
+# Statically compile and output to tmp
+RUN go mod download && \
     CGO_ENABLED=0 go build -o /tmp/strelka-filestream .
 
-# Move build, install additional packages, and initialize non-root user
+# Initialize runtime container
 FROM alpine
+LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
+
+# Copy binary
 COPY --from=build /tmp/strelka-filestream /usr/local/bin/strelka-filestream
+
+# Install jq
 RUN apk add --no-cache jq
+
+# Initialize with non-root user
 USER 1001
+
+# Set container entrypoint. This could be set/overridden elsewhere in deployment (e.g. k8s, docker-compose, etc.)
+# Currently overwritten in ./build/docker-compose.yml
+ENTRYPOINT ["strelka-filestream"]

--- a/build/go/frontend/Dockerfile
+++ b/build/go/frontend/Dockerfile
@@ -1,20 +1,32 @@
+# Strelka Frontend
+# The frontend for a cluster in which clients can connect directly via Envoy.
+# For more information, please see: https://target.github.io/strelka/#/?id=strelka-frontend
 FROM golang AS build
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 # Copy source files and set the working directory
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-WORKDIR /go/src/github.com/target/strelka/src/go/
+WORKDIR /go/src/github.com/target/strelka/src/go/cmd/strelka-frontend
 
-# Initialize, get, and build go modules and main package
-RUN go mod init && \
-    go mod tidy && \
-    cd /go/src/github.com/target/strelka/src/go/cmd/strelka-frontend/ && \
+# Statically compile and output to tmp
+RUN go mod download && \
     CGO_ENABLED=0 go build -o /tmp/strelka-frontend .
 
-# Move build, create default logging directory, and initialize non-root user
+# Initialize runtime container
 FROM alpine
+LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
+
+# Copy binary
 COPY --from=build /tmp/strelka-frontend /usr/local/bin/strelka-frontend
+
+# Create logging directory
 RUN mkdir /var/log/strelka/ && \
     chgrp -R 0 /var/log/strelka/ && \
     chmod -R g=u /var/log/strelka/
+
+# Initialize with non-root user
 USER 1001
+
+# Set container entrypoint. This could be set/overridden elsewhere in deployment (e.g. k8s, docker-compose, etc.)
+# Currently overwritten in ./build/docker-compose.yml
+ENTRYPOINT ["strelka-frontend"]

--- a/build/go/manager/Dockerfile
+++ b/build/go/manager/Dockerfile
@@ -1,17 +1,25 @@
+# Strelka Manager
+# Manages portions of Strelka's Redis database.
+# For more information, please see: https://target.github.io/strelka/#/?id=strelka-manager
 FROM golang AS build
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 # Copy source files and set the working directory
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-WORKDIR /go/src/github.com/target/strelka/src/go/
+WORKDIR /go/src/github.com/target/strelka/src/go/cmd/strelka-manager
 
-# Initialize, get, and build go modules and main package
-RUN go mod init && \
-    go mod tidy && \
-    cd /go/src/github.com/target/strelka/src/go/cmd/strelka-manager/ && \
+# Statically compile and output to /tmp
+RUN go mod download && \
     CGO_ENABLED=0 go build -o /tmp/strelka-manager .
 
-# Move build and initialize non-root user
+# Initialize runtime container with non-root user
 FROM alpine
-COPY --from=build /tmp/strelka-manager /usr/local/bin/strelka-manager
 USER 1001
+LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
+
+# Copy binary to /usr/local/bin
+COPY --from=build /tmp/strelka-manager /usr/local/bin/strelka-manager
+
+# Set container entrypoint. This could be set/overridden elsewhere in deployment (e.g. k8s, docker-compose, etc.)
+# Currently overwritten in ./build/docker-compose.yml
+ENTRYPOINT ["strelka-manager"]

--- a/build/go/oneshot/Dockerfile
+++ b/build/go/oneshot/Dockerfile
@@ -1,18 +1,30 @@
+# Strelka Oneshot
+# Client is designed to be used to submit a single file from command line and receive the result for it immediately.
+# For more information, please see: https://target.github.io/strelka/#/?id=strelka-oneshot
 FROM golang AS build
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
 # Copy source files and set the working directory
 COPY ./src/go/ /go/src/github.com/target/strelka/src/go/
-WORKDIR /go/src/github.com/target/strelka/src/go/
+WORKDIR /go/src/github.com/target/strelka/src/go/cmd/strelka-oneshot
 
-# Initialize, get, and build go modules and main package
-RUN go mod init && \
-    go mod tidy && \
-    cd /go/src/github.com/target/strelka/src/go/cmd/strelka-oneshot/ && \
+# Statically compile and output to tmp
+RUN go mod download && \
     CGO_ENABLED=0 go build -o /tmp/strelka-oneshot .
 
-# Move build and initialize non-root user
+# Initialize runtime container
 FROM alpine
+LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
+
+# Copy binary
 COPY --from=build /tmp/strelka-oneshot /usr/local/bin/strelka-oneshot
+
+# Install jq
 RUN apk add --no-cache jq
+
+# Initialize with non-root user
 USER 1001
+
+# Set container entrypoint. This could be set/overridden elsewhere in deployment (e.g. k8s, docker-compose, etc.)
+# Currently overwritten in ./build/docker-compose.yml
+ENTRYPOINT ["strelka-oneshot"]

--- a/src/go/cmd/strelka-fileshot/go.mod
+++ b/src/go/cmd/strelka-fileshot/go.mod
@@ -1,0 +1,9 @@
+module strelka-fileshot
+
+go 1.16
+
+require (
+	github.com/target/strelka v0.0.0-20210303022705-6e2487457d16
+	google.golang.org/grpc v1.36.0
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/src/go/cmd/strelka-filestream/go.mod
+++ b/src/go/cmd/strelka-filestream/go.mod
@@ -1,0 +1,9 @@
+module strelka-filestream
+
+go 1.16
+
+require (
+	github.com/target/strelka v0.0.0-20210303022705-6e2487457d16
+	google.golang.org/grpc v1.36.0
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/src/go/cmd/strelka-frontend/go.mod
+++ b/src/go/cmd/strelka-frontend/go.mod
@@ -1,0 +1,11 @@
+module strelka-frontend
+
+go 1.16
+
+require (
+	github.com/go-redis/redis/v8 v8.8.0
+	github.com/google/uuid v1.2.0
+	github.com/target/strelka v0.0.0-20210303022705-6e2487457d16
+	google.golang.org/grpc v1.36.0
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/src/go/cmd/strelka-manager/go.mod
+++ b/src/go/cmd/strelka-manager/go.mod
@@ -1,0 +1,10 @@
+module strelka-manager
+
+go 1.16
+
+require (
+	github.com/go-redis/redis/v8 v8.8.0
+	github.com/target/strelka v0.0.0-20210303022705-6e2487457d16
+	google.golang.org/grpc v1.36.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/src/go/cmd/strelka-oneshot/go.mod
+++ b/src/go/cmd/strelka-oneshot/go.mod
@@ -1,0 +1,8 @@
+module strelka-oneshot
+
+go 1.16
+
+require (
+	github.com/target/strelka v0.0.0-20210303022705-6e2487457d16
+	google.golang.org/grpc v1.36.0
+)


### PR DESCRIPTION
**Describe the change**
The `go.mod` file was originally generated with:
`go mod init strelka-manager && go mod tidy`

The `go.mod` file is now copied to the build container instead of being
regenerated with every build. This enables quicker builds and makes
things like version pinning more straightforward.

**Dockerfile Updates:**

- The `RUN go mod download` step creates a cached image layer 
with external dependencies downloaded. The cache should enable 
quicker builds whenever the imports remain unchanged. 
 
- Set the container entrypoint as an example. 
This is currently being overridden by docker-compose.

- It's important to note that if any of these containers
are updated in the future that the `mod` files be updated
as well.

**Describe testing procedures**
Built and ran fresh images with several hundred scans over a period 
of an hour. No issues.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
