### PR TITLE
ScanPDF Replacement

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -14,7 +14,6 @@ msoffcrypto-tool==4.10.1
 olefile==0.46
 oletools==0.55.1
 M2Crypto==0.35.2
-pdfminer.six==20200124
 pefile==2019.4.18
 pgpdump3==1.5.2
 pylzma==0.5.0
@@ -22,6 +21,7 @@ pygments==2.6.1
 python-docx==0.8.10
 git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (package installed as 'entropy')
 python-magic==0.4.15
+pymupdf==1.18.10
 pyyaml>=4.2b1
 rarfile==3.1
 redis==3.4.1

--- a/configs/python/backend/logging.yaml
+++ b/configs/python/backend/logging.yaml
@@ -48,7 +48,7 @@ loggers:
     propagate: 0
   oletools:
     propagate: 0
-  pdfminer:
+  pymupdf:
     propagate: 0
   pefile:
     propagate: 0

--- a/misc/kubernetes/backend-configmap.yaml
+++ b/misc/kubernetes/backend-configmap.yaml
@@ -553,7 +553,7 @@ data:
         propagate: 0
       oletools:
         propagate: 0
-      pdfminer:
+      pymupdf:
         propagate: 0
       pefile:
         propagate: 0


### PR DESCRIPTION
**Describe the change**
The current ScanPDF scanner utilizes the package: `pdfminer.six`.
It's implementation in Strelka resulted in one of the
longest running scanners in the Strelka scanner suite. A replacement
effort was made to identify another PDF library that provided similar
requirements (text, url, annotation extraction) but with an increased
runtime.

The following libraries were tested:

1. PDFPlumber
2. PDFQuery
3. PDFRW
4. PDFToText
5. PDFX
6. PikePDF
7. PyMuPDF
8. PyPDF2

While most of these fit the basic requirements needed to replace
`pdfminer.six`, the package `PyMuPDF` was selected from a series
of performance tests to be the replacement. 

An example of the tests can be summed up with the following metric
to display the performance increase:

**Test: Load and parse a 50 page PDF file**
`pdfminer.six`: 9.990271 seconds
`PyMuPDF`: **0.515679 seconds**

This change closes #34.

**Describe testing procedures**
Upon replacing the ScanPDF scanner with `PyMuPDF`, a fresh Strelka 
build was generated and several hundred PDF scans were submitted to 
examine output. Output was as expected.

**Sample output**
```
{
  "file": {
    "depth": 0,
    "flavors": {
      "mime": [
        "application/pdf"
      ],
      "yara": [
        "pdf_file"
      ]
    },
    "scanners": [
      "ScanEntropy",
      "ScanExiftool",
      "ScanHash",
      "ScanHeader",
      "ScanPdf",
      "ScanYara"
    ],
    "size": 3996084,
    "tree": {
      "node": "de586f14-28da-4d52-8a78-4b33880bbe65",
      "root": "de586f14-28da-4d52-8a78-4b33880bbe65"
    }
  },
  "request": {
    "attributes": {
      "filename": "/Users/z0029zb/Desktop/personal/pdfs_performance/sample_data1/sample-pages_1-50.pdf"
    },
    "client": "go-fileshot-testing",
    "id": "de586f14-28da-4d52-8a78-4b33880bbe65",
    "source": "f8ffc251aa95",
    "time": 1616787160
  },
  "scan": {
    "entropy": {
      "elapsed": 0.002366,
      "entropy": 7.322427728595489
    },
    "exiftool": {
      "elapsed": 0.198568,
      "keys": [
        {
          "key": "PDFVersion",
          "value": 1.3
        },
        {
          "key": "Linearized",
          "value": "No"
        },
        {
          "key": "PageCount",
          "value": 50
        },
        {
          "key": "Producer",
          "value": "PyPDF2"
        }
      ]
    },
    "hash": {
      "elapsed": 0.044103,
      "md5": "349db4961c72e09aed1e776fbb6b195b",
      "sha1": "764eeb1be831382ffb890bb30f1f2d1b542b3d57",
      "sha256": "744ed276263578cc0924cea262e26b0208dc624ce6852f383284f437ca2ba7cf",
      "ssdeep": "49152:/m5P3wMm2/fSEByS+lp7L2I3xnZlrw7Rh+ZxZqk0ANo:WAMDVytBL2UxnZp8wZxZqrAW"
    },
    "header": {
      "elapsed": 0.000046,
      "header": "%PDF-1.3\n1 0 obj\n<<\n/Type /Pages\n/Count 50\n/Kids ["
    },
    "pdf": {
      "elapsed": 0.515679,
      "total": {
        "extracted": 1747,
        "objects": 0
      }
    },
    "yara": {
      "elapsed": 0.000115,
      "flags": [
        "compiling_error"
      ]
    }
  }
}
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
