### PR TITLE
Improving Dockerfiles for Rebuilds

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -6,11 +6,6 @@ ARG YARA_VERSION=4.0.5
 ARG YARA_PYTHON_VERSION=4.0.3
 ARG CAPA_VERSION=1.1.0
 
-# Copy Strelka files
-COPY ./src/python/ /strelka/
-COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
-COPY ./build/python/backend/setup.py /strelka/setup.py
-
 # Update packages
 RUN apt-get -qq update && \
 # Install build packages
@@ -63,9 +58,6 @@ RUN apt-get -qq update && \
     cd /tmp/ && \
     curl -OL https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/linux/dist/floss && \
     chmod +x /tmp/floss && \
-# Install Python packages
-    pip3 install -r /strelka/requirements.txt && \
-    pip3 install --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com lief && \
 # Install YARA
     cd /tmp/ && \
     curl -OL https://github.com/VirusTotal/yara/archive/v$YARA_VERSION.tar.gz && \
@@ -80,9 +72,18 @@ RUN apt-get -qq update && \
     tar -zxvf v$YARA_PYTHON_VERSION.tar.gz && \
     cd yara-python-$YARA_PYTHON_VERSION/ && \
     python3 setup.py build --dynamic-linking && \
-    python3 setup.py install && \
+    python3 setup.py install
+
+# Install Python packages
+COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
+RUN pip3 install --no-cache-dir -r /strelka/requirements.txt && \
+    pip3 install --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com lief
+
+COPY ./src/python/ /strelka/
+COPY ./build/python/backend/setup.py /strelka/setup.py
+
 # Install Strelka
-    cd /strelka/ && \
+RUN cd /strelka/ && \
     python3 setup.py -q build && \
     python3 setup.py -q install && \
 # Remove build packages
@@ -107,4 +108,7 @@ RUN apt-get -qq update && \
     mkdir /var/log/strelka/ && \
     chgrp -R 0 /var/log/strelka/ && \
     chmod -R g=u /var/log/strelka/
+
+# Copy Strelka files
+
 USER 1001

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -79,6 +79,7 @@ COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
 RUN pip3 install --no-cache-dir -r /strelka/requirements.txt && \
     pip3 install --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com lief
 
+# Copy Strelka files
 COPY ./src/python/ /strelka/
 COPY ./build/python/backend/setup.py /strelka/setup.py
 
@@ -109,6 +110,5 @@ RUN cd /strelka/ && \
     chgrp -R 0 /var/log/strelka/ && \
     chmod -R g=u /var/log/strelka/
 
-# Copy Strelka files
 
 USER 1001

--- a/build/python/mmrpc/Dockerfile
+++ b/build/python/mmrpc/Dockerfile
@@ -2,11 +2,6 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
-# Copy Strelka files
-COPY ./src/python/ /strelka/
-COPY ./build/python/mmrpc/requirements.txt /strelka/requirements.txt
-COPY ./build/python/mmrpc/setup.py /strelka/setup.py
-
 # Update packages
 RUN apt-get -qq update && \
     apt-get install --no-install-recommends -qq \
@@ -15,11 +10,17 @@ RUN apt-get -qq update && \
     python3-dev \
     python3-pip \
     python3-setuptools \
-    python3-wheel && \
-# Install Python packages
-    pip3 install -r /strelka/requirements.txt && \
+    python3-wheel
+
+#Install Strelka Requirements
+COPY ./build/python/mmrpc/requirements.txt /strelka/requirements.txt
+RUN pip3 install --no-cache-dir -r /strelka/requirements.txt
+
+COPY ./src/python/ /strelka/
+COPY ./build/python/mmrpc/setup.py /strelka/setup.py
+
 # Install Strelka
-    cd /strelka/ && \
+RUN cd /strelka/ && \
     python3 setup.py -q build && \
     python3 setup.py -q install && \
 # Remove build packages
@@ -34,4 +35,5 @@ RUN apt-get -qq update && \
     apt-get purge -qq python3-setuptools  && \
     apt-get clean -qq && \
     rm -rf /var/lib/apt/lists/* /strelka/
+
 USER 1001


### PR DESCRIPTION
**Describe the change**
* Reduces time to REBUILD from ~8 minutes to ~11 seconds upon creating new or modifying scanner.
* Follow's Dockerfile best practices by layer caching dependencies. 
* Should make new scanner development more efficient for editing, testing, modifying.

**Describe testing procedures**
* Forked the repo, testing building with and without changes, still builds OK and is drastically faster on REBUILDS.

**Sample output**
* No changes to final built images

**Checklist**
- [ * ] My code follows the style guidelines of this project
- [ * ] I have performed a self-review of and tested my code
- [ * ] I have commented my code, particularly in hard-to-understand areas
- [ * ] I have made corresponding changes to the documentation
- [ * ] My changes generate no new warnings
