### PR TITLE
Refactor scan pe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2021-6-10
+### Added
+- `scan_pe` refactor / additions (@swackhamer)
+
 ## 2021-5-14
 ### Added
 - `scan_qr` QR code scanner (@aaronherman)

--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -1,8 +1,13 @@
+import datetime
 import binascii
+import logging
+import hashlib
 import struct
+from io import BytesIO
 
 import pefile
-
+from signify.exceptions import *
+from signify.signed_pe import SignedPEFile
 from strelka import strelka
 
 CHARACTERISTICS_DLL = {
@@ -206,6 +211,91 @@ VAR_FILE_INFO_CHARS = {
     1255: 'Hebrew',
     1256: 'Arabic',
 }
+COMMON_FILE_INFO_NAMES = {
+    "Assembly Version": "assembly_version",
+    "Build Description": "build_description",
+    "Comments": "comments",
+    "CompanyName": "company_name",
+    "FileDescription": "file_description",
+    "FileVersion": "file_version",
+    "InternalName": "internal_name",
+    "LegalCopyright": "legal_copyright",
+    "LegalTrademarks": "legal_trademarks",
+    "License": "license",
+    "OLESelfRegister": "ole_self_register",
+    "OriginalFilename": "original_filename",
+    "PrivateBuild": "private_build",
+    "ProductName": "product_name",
+    "ProductVersion": "product_version"
+}
+
+
+def parse_certificates(data):
+    # set up string io as we get data
+    buffer = BytesIO()
+    buffer.write(data)
+    buffer.seek(0)
+
+    try:
+        pefile = SignedPEFile(buffer)
+        signed_datas = list(pefile.signed_datas)
+    except (SignedPEParseError, SignerInfoParseError, AuthenticodeParseError, VerificationError,
+            CertificateVerificationError, SignerInfoVerificationError, AuthenticodeVerificationError) as e:
+        logging.info(f"signify threw error {e} when processing PE file")
+        return {}
+
+    cert_list = []
+    signer_list = []
+    counter_signer_list = []
+
+    for signed_data in signed_datas:
+        try:
+            certs = signed_data.certificates
+            for cert in certs:
+                asn1 = cert.to_asn1crypto
+                issuer = asn1.issuer.native
+                cert_dict = {
+                    "country_name": issuer.get("country_name"),
+                    "organization_name": issuer.get("organization_name"),
+                    "organizational_unit_name": issuer.get("organizational_unit_name"),
+                    "common_name": issuer.get("common_name"),
+                    "serial_number": str(cert.serial_number),
+                    "issuer_dn": cert.issuer_dn,
+                    "subject_dn": cert.subject_dn,
+                    "valid_from": cert.valid_from.isoformat(),
+                    "valid_to": cert.valid_to.isoformat(),
+                    # "signature_algorithim": cert.signature_algorithm
+                }
+                cert_list.append(cert_dict)
+
+            signer_dict = {'issuer': signed_data.signer_info.issuer_dn,
+                           'serial': str(signed_data.signer_info.serial_number),
+                           'program_name': signed_data.signer_info.program_name,
+                           'more_info': signed_data.signer_info.more_info}
+            # signer information
+            signer_list.append(signer_dict)
+
+            if signed_data.signer_info.countersigner:
+                counter_signer_dict = {'issuer_dn': signed_data.signer_info.countersigner.issuer_dn,
+                                       'serial_number': str(signed_data.signer_info.countersigner.serial_number),
+                                       'signing_time': signed_data.signer_info.countersigner.signing_time.isoformat()}
+                counter_signer_list.append(counter_signer_dict)
+
+        except SignedPEParseError:
+            logging.debug("no certificate in signed data")
+
+    security_dict = {'certificates': cert_list,
+                     'signers': signer_list,
+                     'counter_signers': counter_signer_list}
+
+    try:
+        pefile.verify()
+        security_dict["verification"] = True
+    except Exception as e:
+        security_dict['verification'] = False
+        security_dict['verification_error'] = str(e)
+
+    return security_dict
 
 
 class ScanPe(strelka.Scanner):
@@ -217,12 +307,17 @@ class ScanPe(strelka.Scanner):
             self.flags.append('pe_format_error')
             return
 
+        cert_dict = parse_certificates(data)
+        if cert_dict:
+            self.event['security'] = cert_dict
+
         self.event['total'] = {
             'libraries': 0,
             'resources': 0,
             'sections': len(pe.sections),
             'symbols': 0,
         }
+        self.event['summary'] = {}
 
         if hasattr(pe, 'DIRECTORY_ENTRY_DEBUG'):
             for d in pe.DIRECTORY_ENTRY_DEBUG:
@@ -255,16 +350,20 @@ class ScanPe(strelka.Scanner):
             'var': {},
         }
 
+        # https://github.com/erocarrera/pefile/blob/master/pefile.py#L3553
         if hasattr(pe, 'FileInfo'):
             fi = pe.FileInfo[0]  # contains a single element
             for i in fi:
                 if i.Key == b'StringFileInfo':
                     for st in i.StringTable:
                         for k, v in st.entries.items():
-                            self.event['file_info']['string'].append({
-                                'name': k.decode(),
-                                'value': v.decode(),
-                            })
+                            if k.decode() in COMMON_FILE_INFO_NAMES:
+                                self.event['file_info'][COMMON_FILE_INFO_NAMES[k.decode()]] = v.decode()
+                            else:
+                                self.event['file_info']['string'].append({
+                                    'name': k.decode(),
+                                    'value': v.decode(),
+                                })
                 elif i.Key == b'VarFileInfo':
                     for v in i.Var:
                         translation = v.entry.get(b'Translation')
@@ -295,20 +394,6 @@ class ScanPe(strelka.Scanner):
                     self.event['file_info']['fixed']['operating_systems'].append(FIXED_FILE_INFO_OS[o])
 
         self.event['header'] = {
-            'address': {
-                'code': pe.OPTIONAL_HEADER.BaseOfCode,
-                'entry_point': pe.OPTIONAL_HEADER.AddressOfEntryPoint,
-                'image': pe.OPTIONAL_HEADER.ImageBase,
-            },
-            'alignment': {
-                'file': pe.OPTIONAL_HEADER.FileAlignment,
-                'section': pe.OPTIONAL_HEADER.SectionAlignment,
-            },
-            'characteristics': {
-                'dll': [],
-                'image': [],
-            },
-            'checksum': pe.OPTIONAL_HEADER.CheckSum,
             'machine': {
                 'id': pe.FILE_HEADER.Machine,
                 'type': pefile.MACHINE_TYPE.get(pe.FILE_HEADER.Machine).replace('IMAGE_FILE_MACHINE_', ''),
@@ -317,114 +402,146 @@ class ScanPe(strelka.Scanner):
                 'dos': MAGIC_DOS.get(pe.DOS_HEADER.e_magic, ''),
                 'image': MAGIC_IMAGE.get(pe.OPTIONAL_HEADER.Magic, ''),
             },
-            'size': {
-                'code': pe.OPTIONAL_HEADER.SizeOfCode,
-                'data': {
-                    'initialized': pe.OPTIONAL_HEADER.SizeOfInitializedData,
-                    'uninitialized': pe.OPTIONAL_HEADER.SizeOfUninitializedData,
-                },
-                'headers': pe.OPTIONAL_HEADER.SizeOfHeaders,
-                'heap': {
-                    'reserve': pe.OPTIONAL_HEADER.SizeOfHeapReserve,
-                    'commit': pe.OPTIONAL_HEADER.SizeOfHeapCommit,
-                },
-                'image': pe.OPTIONAL_HEADER.SizeOfImage,
-                'stack': {
-                    'commit': pe.OPTIONAL_HEADER.SizeOfStackCommit,
-                    'reserve': pe.OPTIONAL_HEADER.SizeOfStackReserve,
-                },
-            },
             'subsystem': pefile.SUBSYSTEM_TYPE.get(pe.OPTIONAL_HEADER.Subsystem).replace('IMAGE_SUBSYSTEM_', ''),
-            'timestamp': pe.FILE_HEADER.TimeDateStamp,
-            'version': {
-                'image': float(f'{pe.OPTIONAL_HEADER.MajorImageVersion}.{pe.OPTIONAL_HEADER.MinorImageVersion}'),
-                'linker': float(f'{pe.OPTIONAL_HEADER.MajorLinkerVersion}.{pe.OPTIONAL_HEADER.MinorLinkerVersion}'),
-                'operating_system': float(f'{pe.OPTIONAL_HEADER.MajorOperatingSystemVersion}.{pe.OPTIONAL_HEADER.MinorOperatingSystemVersion}'),
-                'subsystem': float(f'{pe.OPTIONAL_HEADER.MajorSubsystemVersion}.{pe.OPTIONAL_HEADER.MinorSubsystemVersion}'),
-            },
         }
 
-        if hasattr(pe.OPTIONAL_HEADER, 'BaseOfData'):
-            self.event['header']['address']['data'] = pe.OPTIONAL_HEADER.BaseOfData
+        self.event['base_of_code'] = pe.OPTIONAL_HEADER.BaseOfCode
+        self.event['address_of_entry_point'] = pe.OPTIONAL_HEADER.AddressOfEntryPoint
+        self.event['image_base'] = pe.OPTIONAL_HEADER.ImageBase
+        self.event['size_of_code'] = pe.OPTIONAL_HEADER.SizeOfCode
+        self.event['size_of_initialized_data'] = pe.OPTIONAL_HEADER.SizeOfInitializedData
+        self.event['size_of_headers'] = pe.OPTIONAL_HEADER.SizeOfHeaders
+        self.event['size_of_heap_reserve'] = pe.OPTIONAL_HEADER.SizeOfHeapReserve
+        self.event['size_of_image'] = pe.OPTIONAL_HEADER.SizeOfImage
+        self.event['size_of_stack_commit'] = pe.OPTIONAL_HEADER.SizeOfStackCommit
+        self.event['size_of_stack_reserve'] = pe.OPTIONAL_HEADER.SizeOfStackReserve
+        self.event['size_of_heap_commit'] = pe.OPTIONAL_HEADER.SizeOfHeapCommit
+        self.event['size_of_uninitalized_data'] = pe.OPTIONAL_HEADER.SizeOfUninitializedData
+        self.event['file_alignment'] = pe.OPTIONAL_HEADER.FileAlignment
+        self.event['section_alignment'] = pe.OPTIONAL_HEADER.SectionAlignment
+        self.event['checksum'] = pe.OPTIONAL_HEADER.CheckSum
 
+        self.event['major_image_version'] = pe.OPTIONAL_HEADER.MajorImageVersion
+        self.event['minor_image_version'] = pe.OPTIONAL_HEADER.MinorImageVersion
+        self.event['major_linker_version'] = pe.OPTIONAL_HEADER.MajorLinkerVersion
+        self.event['minor_linker_version'] = pe.OPTIONAL_HEADER.MinorLinkerVersion
+        self.event['major_operating_system_version'] = pe.OPTIONAL_HEADER.MajorOperatingSystemVersion
+        self.event['minor_operating_system_version'] = pe.OPTIONAL_HEADER.MinorOperatingSystemVersion
+        self.event['major_subsystem_version'] = pe.OPTIONAL_HEADER.MajorSubsystemVersion
+        self.event['minor_subsystem_version'] = pe.OPTIONAL_HEADER.MinorSubsystemVersion
+        self.event['image_version'] = float(f'{pe.OPTIONAL_HEADER.MajorImageVersion}.{pe.OPTIONAL_HEADER.MinorImageVersion}')
+        self.event['linker_version'] = float(f'{pe.OPTIONAL_HEADER.MajorLinkerVersion}.{pe.OPTIONAL_HEADER.MinorLinkerVersion}')
+        self.event['operating_system_version'] = float(f'{pe.OPTIONAL_HEADER.MajorOperatingSystemVersion}.{pe.OPTIONAL_HEADER.MinorOperatingSystemVersion}')
+        self.event['subsystem_version'] = float(f'{pe.OPTIONAL_HEADER.MajorSubsystemVersion}.{pe.OPTIONAL_HEADER.MinorSubsystemVersion}')
+
+        try:
+            self.event['compile_time'] = datetime.datetime.utcfromtimestamp(pe.FILE_HEADER.TimeDateStamp).isoformat()
+        except OverflowError:
+            logging.info("invalid compile time caused an overflow error")
+
+        if hasattr(pe.OPTIONAL_HEADER, 'BaseOfData'):
+            self.event['base_of_data'] = pe.OPTIONAL_HEADER.BaseOfData
+
+        dll_characteristics = []
         for o in CHARACTERISTICS_DLL:
             if pe.OPTIONAL_HEADER.DllCharacteristics & o:
-                self.event['header']['characteristics']['dll'].append(CHARACTERISTICS_DLL[o])
+                dll_characteristics.append(CHARACTERISTICS_DLL[o])
 
+        if dll_characteristics:
+            self.event['dll_characteristics'] = dll_characteristics
+
+        image_characteristics = []
         for o in CHARACTERISTICS_IMAGE:
             if pe.FILE_HEADER.Characteristics & o:
-                self.event['header']['characteristics']['image'].append(CHARACTERISTICS_IMAGE[o])
+                image_characteristics.append(CHARACTERISTICS_IMAGE[o])
+
+        if image_characteristics:
+            self.event['image_characteristics'] = image_characteristics
 
         self.event['resources'] = []
         if hasattr(pe, 'DIRECTORY_ENTRY_RESOURCE'):
+            resource_md5_set = set()
+            resource_sha1_set = set()
+            resource_sha256_set = set()
+
             for res0 in pe.DIRECTORY_ENTRY_RESOURCE.entries:
                 for res1 in res0.directory.entries:
-                    name = ''
-                    if res1.name:
-                        name = str(res1.name)
-
                     for res2 in res1.directory.entries:
                         lang = res2.data.lang
                         sub = res2.data.sublang
                         sub = pefile.get_sublang_name_for_lang(lang, sub)
-                        lang = pefile.LANG.get(lang, '')
-                        self.event['resources'].append({
+                        data = pe.get_data(res2.data.struct.OffsetToData, res2.data.struct.Size)
+
+                        resource_md5 = hashlib.md5(data).hexdigest()
+                        resource_sha1 = hashlib.sha1(data).hexdigest()
+                        resource_sha256 = hashlib.sha256(data).hexdigest()
+                        resource_md5_set.add(resource_md5)
+                        resource_sha1_set.add(resource_sha1)
+                        resource_sha256_set.add(resource_sha256)
+
+                        resource_dict = {
                             'id': res1.id,
-                            'name': name,
                             'language': {
-                                'primary': lang.replace('LANG_', ''),
                                 'sub': sub.replace('SUBLANG_', '')
                             },
                             'type': pefile.RESOURCE_TYPE.get(res0.id, '').replace('RT_', ''),
-                        })
+                            'md5': resource_md5,
+                            'sha1': resource_sha1,
+                            'sha256': resource_sha256,
+                        }
 
-                        data = pe.get_data(res2.data.struct.OffsetToData, res2.data.struct.Size)
-                        if len(data) > 0:
-                            extract_file = strelka.File(
-                                name=f'{name or res1.id}',
-                                source=f'{self.name}::Resource',
-                            )
-                            for c in strelka.chunk_string(data):
-                                self.upload_to_coordinator(
-                                    extract_file.pointer,
-                                    c,
-                                    expire_at,
-                                )
-                            self.files.append(extract_file)
+                        if lang in pefile.LANG:
+                            resource_dict['language']['primary'] = pefile.LANG[lang].replace('LANG_', '')
+
+                        if res1.name:
+                            resource_dict['name'] = str(res1.name)
+
+                        self.event['resources'].append(resource_dict)
+
+            self.event['summary']['resource_md5'] = list(resource_md5_set)
+            self.event['summary']['resource_sha1'] = list(resource_sha1_set)
+            self.event['summary']['resource_sha256'] = list(resource_sha256_set)
 
         self.event['total']['resources'] = len(self.event['resources'])
 
         self.event['sections'] = []
+        section_md5_set = set()
+        section_sha1_set = set()
+        section_sha256_set = set()
+
         for sec in pe.sections:
-            name = sec.Name.rstrip(b'\x00').decode()
-            row = {
-                'address': {
-                    'physical': sec.Misc_PhysicalAddress,
-                    'virtual': sec.VirtualAddress,
-                },
-                'characteristics': [],
-                'entropy': sec.get_entropy(),
-                'name': name,
-                'size': sec.SizeOfRawData,
-            }
-            for o in CHARACTERISTICS_SECTION:
-                if sec.Characteristics & o:
-                    row['characteristics'].append(CHARACTERISTICS_SECTION[o])
+            try:
+                name = sec.Name.rstrip(b'\x00').decode()
+                section_md5 = sec.get_hash_md5()
+                section_sha1 = sec.get_hash_sha1()
+                section_sha256 = sec.get_hash_sha256()
 
-            if sec.SizeOfRawData > 0:
-                extract_file = strelka.File(
-                    name=name,
-                    source=f'{self.name}::Section',
-                )
-                for c in strelka.chunk_string(sec.get_data()):
-                    self.upload_to_coordinator(
-                        extract_file.pointer,
-                        c,
-                        expire_at,
-                    )
-                self.files.append(extract_file)
+                section_md5_set.add(section_md5)
+                section_sha1_set.add(section_sha1)
+                section_sha256_set.add(section_sha256)
+                row = {
+                    'address': {
+                        'physical': sec.Misc_PhysicalAddress,
+                        'virtual': sec.VirtualAddress,
+                    },
+                    'characteristics': [],
+                    'entropy': sec.get_entropy(),
+                    'name': name,
+                    'size': sec.SizeOfRawData,
+                    'md5': section_md5,
+                    'sha1': section_sha1,
+                    'sha256': section_sha256,
+                }
+                for o in CHARACTERISTICS_SECTION:
+                    if sec.Characteristics & o:
+                        row['characteristics'].append(CHARACTERISTICS_SECTION[o])
 
-            self.event['sections'].append(row)
+                self.event['sections'].append(row)
+                self.event['summary']['section_md5'] = list(section_md5_set)
+                self.event['summary']['section_sha1'] = list(section_sha1_set)
+                self.event['summary']['section_sha256'] = list(section_sha256_set)
+            except Exception as e:
+                logging.warning(f"exception thrown when parsing section's {e}")
 
         self.event['symbols'] = {
             'exported': [],
@@ -470,22 +587,3 @@ class ScanPe(strelka.Scanner):
 
         self.event['total']['libraries'] = len(self.event['symbols']['libraries'])
         self.event['total']['symbols'] = len(self.event['symbols']['table'])
-
-        security = pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_SECURITY']]
-        sec_addr = security.VirtualAddress
-        if security.Size > 0:
-            data = pe.write()[sec_addr + 8:]
-            if len(data) > 0:
-                self.flags.append('signed')
-
-                extract_file = strelka.File(
-                    name='signature',
-                    source=f'{self.name}::Security',
-                )
-                for c in strelka.chunk_string(data):
-                    self.upload_to_coordinator(
-                        extract_file.pointer,
-                        c,
-                        expire_at,
-                    )
-                self.files.append(extract_file)


### PR DESCRIPTION
**Describe the change**
Refactored scan_pe scanner, cleaning up the codebase and adding in additional collection fields.

**Describe testing procedures**
Extensive testing in local / internal Strelka environment with thousands of PE files.

**Sample output**
```{
  "file": {
    "depth": 0,
    "flavors": {
      "mime": [
        "application/x-dosexec"
      ],
      "yara": [
        "mz_file"
      ]
    },
    "scanners": [
      "ScanEntropy",
      "ScanFooter",
      "ScanHash",
      "ScanHeader",
      "ScanPe",
      "ScanYara"
    ],
    "size": 2378752,
    "tree": {
      "node": "de1a7dd0-2534-4549-aa7f-8f00e526fdf6",
      "root": "de1a7dd0-2534-4549-aa7f-8f00e526fdf6"
    }
  },
  "request": {
    "attributes": {
      "filename": "samples/scan_pe/f63ebbb6c6893ee5910623bd4b17b6c9180f42225f3e901b725e72f6825cbb6d"
    },
    "client": "go-fileshot-testing",
    "id": "de1a7dd0-2534-4549-aa7f-8f00e526fdf6",
    "source": "f8ffc251aa95",
    "time": 1623330508
  },
  "scan": {
    "entropy": {
      "elapsed": 0.001472,
      "entropy": 7.137178346587072
    },
    "footer": {
      "elapsed": 9.6e-05,
      "footer": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
    },
    "hash": {
      "elapsed": 0.026227,
      "md5": "6ba094a754412b5deeb3951085a59dc2",
      "sha1": "cede0852922b98c824842b8ab132c53dd41ab3d8",
      "sha256": "f63ebbb6c6893ee5910623bd4b17b6c9180f42225f3e901b725e72f6825cbb6d",
      "ssdeep": "49152:UX1YVj023QxsF3Z4LFjoblKAr0Sr5TsIjKeVPkDB/i8r37UnxNDe:UHsWwyr37eN"
    },
    "header": {
      "elapsed": 0.000175,
      "header": "MZ�\u0000\u0003\u0000\u0000\u0000\u0004\u0000\u0000\u0000��\u0000\u0000�\u0000\u0000\u0000\u0000\u0000\u0000\u0000@\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
    },
    "pe": {
      "address_of_entry_point": 1144016,
      "base_of_code": 4096,
      "checksum": 2431699,
      "compile_time": "2030-12-14T09:24:47",
      "debug": {
        "age": 1,
        "guid": "b64f2994-0f44-6bfa-e5b7334576f1faa7",
        "pdb": "smartscreen.pdb",
        "type": "rsds"
      },
      "dll_characteristics": [
        "HIGH_ENTROPY_VA",
        "DYNAMIC_BASE",
        "NX_COMPAT",
        "GUARD_CF",
        "TERMINAL_SERVER_AWARE"
      ],
      "elapsed": 0.640581,
      "file_alignment": 512,
      "file_info": {
        "company_name": "Microsoft Corporation",
        "file_description": "Windows Defender SmartScreen",
        "file_version": "10.0.19041.844 (WinBuild.160101.0800)",
        "fixed": {
          "operating_systems": [
            "WINDOWS32",
            "NT"
          ],
          "type": {
            "primary": "DLL"
          }
        },
        "internal_name": "smartscreen.exe",
        "legal_copyright": "© Microsoft Corporation. All rights reserved.",
        "original_filename": "smartscreen.exe",
        "product_name": "Microsoft® Windows® Operating System",
        "product_version": "10.0.19041.844",
        "var": {
          "character_set": "Unicode",
          "language": "U.S. English"
        }
      },
      "header": {
        "machine": {
          "id": 34404,
          "type": "AMD64"
        },
        "magic": {
          "dos": "DOS",
          "image": "64_BIT"
        },
        "subsystem": "WINDOWS_GUI"
      },
      "image_base": 5368709120,
      "image_characteristics": [
        "EXECUTABLE_IMAGE",
        "LARGE_ADDRESS_AWARE"
      ],
      "image_version": 10,
      "imphash": "6dfbf12753af176e3c203c407493a5b9",
      "linker_version": 14.2,
      "major_image_version": 10,
      "major_linker_version": 14,
      "major_operating_system_version": 10,
      "major_subsystem_version": 10,
      "minor_image_version": 0,
      "minor_linker_version": 20,
      "minor_operating_system_version": 0,
      "minor_subsystem_version": 0,
      "operating_system_version": 10,
      "resources": [
        {
          "id": 1,
          "language": {
            "primary": "ENGLISH",
            "sub": "ENGLISH_US"
          },
          "md5": "dc503ddc71f3a919c6299d683f80ea3a",
          "sha1": "29005ef043cd8e6d154ec14c6ebaae61b814f9b0",
          "sha256": "89056e08cb59db3b639ff96fdd0544ea5bd7ac1391cf2db1256b82280fd5b13b"
        },
        {
          "id": 1,
          "language": {
            "primary": "ENGLISH",
            "sub": "ENGLISH_US"
          },
          "md5": "870706d1c374bf1e4a7d75bb12d1a76a",
          "sha1": "ad4613f60f89943242e936e15541ec5a79be77de",
          "sha256": "faac556adca1375d3087fdb4dda5a60f69b5b92c504e98306a7a6916b5aede05"
        },
        {
          "id": 1,
          "language": {
            "primary": "ENGLISH",
            "sub": "ENGLISH_US"
          },
          "md5": "39d8fffbec1d95c6e7470c5393d0b70d",
          "sha1": "a20531726c93d8c5b9198c41bd894759983f2d3a",
          "sha256": "35047dc0bea0595bf5925646b3f52bf4ad97962b4055a7b3e13d2246aef29e97",
          "type": "VERSION"
        }
      ],
      "section_alignment": 4096,
      "sections": [
        {
          "address": {
            "physical": 1258873,
            "virtual": 4096
          },
          "characteristics": [
            "CNT_CODE",
            "MEM_EXECUTE",
            "MEM_READ"
          ],
          "entropy": 6.221961079404854,
          "md5": "fbc72e396709debc883773bfa1061971",
          "name": ".text",
          "sha1": "78af1d4d7882da59d576a5bd627be980f961dd71",
          "sha256": "325e96e9814045991050442b74df6a7a9f133618439cead10e45813b27b6b295",
          "size": 1259008
        },
        {
          "address": {
            "physical": 250600,
            "virtual": 1265664
          },
          "characteristics": [
            "CNT_INITIALIZED_DATA",
            "MEM_READ"
          ],
          "entropy": 5.856001664623567,
          "md5": "b9d597b604e3f0020ba4a7744592ad00",
          "name": ".rdata",
          "sha1": "6d0fd09b7847e799e6b5d32c9b39fed4a8595c86",
          "sha256": "a05f2d47b53143e6cdc4c17a35696adfa0ed4ba619d691d1a745e9df4b115868",
          "size": 250880
        },
        {
          "address": {
            "physical": 803616,
            "virtual": 1519616
          },
          "characteristics": [
            "CNT_INITIALIZED_DATA",
            "MEM_READ",
            "MEM_WRITE"
          ],
          "entropy": 7.964113610149093,
          "md5": "bf7e515666ea6e4a15644d1f0436d584",
          "name": ".data",
          "sha1": "a941a4fd570c70e8bb5333bf1253b8d3da3fa261",
          "sha256": "5bd5c8ee35fff62e7eb33a0971804ce95be8e1f68f5ad3c6badc09ec106b2de0",
          "size": 796672
        },
        {
          "address": {
            "physical": 52344,
            "virtual": 2326528
          },
          "characteristics": [
            "CNT_INITIALIZED_DATA",
            "MEM_READ"
          ],
          "entropy": 5.967429715972895,
          "md5": "6ef21b5f37c4558f2d4be11eff4883d4",
          "name": ".pdata",
          "sha1": "db9f0b1486e23565f2337735f9101a0e35812cac",
          "sha256": "79a7aa24cf129004d446fc35fd70dbebc4db6fbb08770bea2cd8d66df3c4232d",
          "size": 52736
        },
        {
          "address": {
            "physical": 200,
            "virtual": 2379776
          },
          "characteristics": [
            "CNT_INITIALIZED_DATA",
            "MEM_READ",
            "MEM_WRITE"
          ],
          "entropy": 1.1853358510933574,
          "md5": "f1605f88ade060188f7dd1817851e7b3",
          "name": ".didat",
          "sha1": "a7521adcb7f283ee40f815b81bbdd198a2c9c359",
          "sha256": "09957c46ebfef26148b3cf5805ce74db3a476d378ad2534a7ee8fc4ebc38c26e",
          "size": 512
        },
        {
          "address": {
            "physical": 5872,
            "virtual": 2383872
          },
          "characteristics": [
            "CNT_INITIALIZED_DATA",
            "MEM_READ"
          ],
          "entropy": 3.562802918867488,
          "md5": "2a18a4c639cc6736c9a7fecc3672f577",
          "name": ".rsrc",
          "sha1": "8307bad70ff3642a17ca0ce073ec00bf495e0852",
          "sha256": "aed12a28dcacc1cc558e25d5cc82c248fa9836f3e45d645de6dbab6fddbabc32",
          "size": 6144
        },
        {
          "address": {
            "physical": 11560,
            "virtual": 2392064
          },
          "characteristics": [
            "CNT_INITIALIZED_DATA",
            "MEM_DISCARDABLE",
            "MEM_READ"
          ],
          "entropy": 5.428018957173279,
          "md5": "ce9b1f2949c55ad76ab2a1bef554a7de",
          "name": ".reloc",
          "sha1": "690ee92df3534607fdfbdddb0acd9e7d12ddabaf",
          "sha256": "e209614e1ecb84e5472bf3b15e7c975c8c33b1c4b28addbb74fb8382eb4e99ed",
          "size": 11776
        }
      ],
      "size_of_code": 1259008,
      "size_of_headers": 1024,
      "size_of_heap_commit": 4096,
      "size_of_heap_reserve": 1048576,
      "size_of_image": 2404352,
      "size_of_initialized_data": 1125888,
      "size_of_stack_commit": 8192,
      "size_of_stack_reserve": 524288,
      "size_of_uninitalized_data": 0,
      "subsystem_version": 10,
      "summary": {
        "resource_md5": [
          "39d8fffbec1d95c6e7470c5393d0b70d",
          "870706d1c374bf1e4a7d75bb12d1a76a",
          "dc503ddc71f3a919c6299d683f80ea3a"
        ],
        "resource_sha1": [
          "ad4613f60f89943242e936e15541ec5a79be77de",
          "a20531726c93d8c5b9198c41bd894759983f2d3a",
          "29005ef043cd8e6d154ec14c6ebaae61b814f9b0"
        ],
        "resource_sha256": [
          "faac556adca1375d3087fdb4dda5a60f69b5b92c504e98306a7a6916b5aede05",
          "35047dc0bea0595bf5925646b3f52bf4ad97962b4055a7b3e13d2246aef29e97",
          "89056e08cb59db3b639ff96fdd0544ea5bd7ac1391cf2db1256b82280fd5b13b"
        ],
        "section_md5": [
          "bf7e515666ea6e4a15644d1f0436d584",
          "2a18a4c639cc6736c9a7fecc3672f577",
          "6ef21b5f37c4558f2d4be11eff4883d4",
          "ce9b1f2949c55ad76ab2a1bef554a7de",
          "f1605f88ade060188f7dd1817851e7b3",
          "fbc72e396709debc883773bfa1061971",
          "b9d597b604e3f0020ba4a7744592ad00"
        ],
        "section_sha1": [
          "db9f0b1486e23565f2337735f9101a0e35812cac",
          "a941a4fd570c70e8bb5333bf1253b8d3da3fa261",
          "78af1d4d7882da59d576a5bd627be980f961dd71",
          "8307bad70ff3642a17ca0ce073ec00bf495e0852",
          "6d0fd09b7847e799e6b5d32c9b39fed4a8595c86",
          "a7521adcb7f283ee40f815b81bbdd198a2c9c359",
          "690ee92df3534607fdfbdddb0acd9e7d12ddabaf"
        ],
        "section_sha256": [
          "a05f2d47b53143e6cdc4c17a35696adfa0ed4ba619d691d1a745e9df4b115868",
          "79a7aa24cf129004d446fc35fd70dbebc4db6fbb08770bea2cd8d66df3c4232d",
          "e209614e1ecb84e5472bf3b15e7c975c8c33b1c4b28addbb74fb8382eb4e99ed",
          "5bd5c8ee35fff62e7eb33a0971804ce95be8e1f68f5ad3c6badc09ec106b2de0",
          "aed12a28dcacc1cc558e25d5cc82c248fa9836f3e45d645de6dbab6fddbabc32",
          "325e96e9814045991050442b74df6a7a9f133618439cead10e45813b27b6b295",
          "09957c46ebfef26148b3cf5805ce74db3a476d378ad2534a7ee8fc4ebc38c26e"
        ]
      },
      "symbols": {
        "imported": [
          "_c_exit",
          "_register_thread_local_exe_atexit_callback",
          "_initialize_onexit_table",
          "__p___wargv",
          "_seh_filter_exe",
          "_crt_atexit",
          "_set_app_type",
          "_beginthreadex",
          "_cexit",
          "_configure_wide_argv",
          "__p___argc",
          "_register_onexit_function",
          "_initialize_wide_environment",
          "_get_initial_wide_environment",
          "abort",
          "_initterm",
          "_exit",
          "terminate",
          "_invalid_parameter_noinfo_noreturn",
          "_initterm_e",
          "_errno",
          "exit",
          "_invalid_parameter_noinfo",
          "__stdio_common_vswprintf_s",
          "__stdio_common_vsnwprintf_s",
          "fflush",
          "ungetc",
          "fseek",
          "_wfsopen",
          "fgetc",
          "fclose",
          "_get_stream_buffer_pointers",
          "__stdio_common_vsnprintf_s",
          "__stdio_common_vswprintf",
          "__stdio_common_vsprintf_s",
          "fputc",
          "fread",
          "__p__commode",
          "fwrite",
          "fgetpos",
          "_fseeki64",
          "fsetpos",
          "_set_fmode",
          "setvbuf",
          "toupper",
          "iswxdigit",
          "iswascii",
          "strcpy_s",
          "_wcsicmp",
          "strnlen",
          "iswdigit",
          "wcsnlen",
          "iswlower",
          "_stricmp",
          "iswspace",
          "towlower",
          "iswupper",
          "isxdigit",
          "strcspn",
          "_wcsdup",
          "isupper",
          "tolower",
          "__strncnt",
          "wcscmp",
          "islower",
          "_malloc_base",
          "_callnewh",
          "realloc",
          "calloc",
          "_free_base",
          "free",
          "_set_new_mode",
          "_calloc_base",
          "malloc",
          "RtlFreeHeap",
          "RtlUnwindEx",
          "RtlLookupFunctionEntry",
          "RtlPcToFileHeader",
          "RtlGetDeviceFamilyInfoEnum",
          "RtlGetVersion",
          "RtlIpv4StringToAddressExW",
          "RtlIpv6StringToAddressExW",
          "RtlIpv4AddressToStringExW",
          "RtlIpv6AddressToStringExW",
          "NtCreateSection",
          "NtQuerySection",
          "ConvertFiberToThread",
          "ConvertThreadToFiber",
          "SwitchToFiber",
          "DeleteFiber",
          "GetModuleHandleExW",
          "GetModuleHandleA",
          "GetProcAddress",
          "GetModuleHandleW",
          "GetModuleFileNameW",
          "LoadLibraryExW",
          "GetModuleFileNameA",
          "FreeLibrary",
          "SizeofResource",
          "LockResource",
          "LoadResource",
          "CreateMutexW",
          "InitializeSRWLock",
          "AcquireSRWLockExclusive",
          "TryAcquireSRWLockExclusive",
          "EnterCriticalSection",
          "OpenSemaphoreW",
          "ReleaseSemaphore",
          "WaitForSingleObject",
          "ResetEvent",
          "WaitForSingleObjectEx",
          "CreateMutexExW",
          "ReleaseSRWLockExclusive",
          "ReleaseMutex",
          "SetEvent",
          "LeaveCriticalSection",
          "InitializeCriticalSectionEx",
          "CreateEventExW",
          "DeleteCriticalSection",
          "InitializeCriticalSectionAndSpinCount",
          "CreateSemaphoreExW",
          "ReleaseSRWLockShared",
          "AcquireSRWLockShared",
          "GetProcessHeap",
          "HeapAlloc",
          "HeapFree",
          "GetLastError",
          "RaiseException",
          "SetLastError",
          "GetProcessId",
          "GetCurrentThread",
          "OpenThreadToken",
          "GetProcessTimes",
          "GetCurrentThreadId",
          "OpenProcessToken",
          "GetExitCodeThread",
          "GetCurrentProcessId",
          "GetCurrentProcess",
          "IdnToAscii",
          "GetThreadPreferredUILanguages",
          "GetLocaleInfoEx",
          "LCMapStringEx",
          "GetUserPreferredUILanguages",
          "GetSystemPreferredUILanguages",
          "SetThreadPreferredUILanguages",
          "FormatMessageW",
          "OutputDebugStringW",
          "IsDebuggerPresent",
          "DebugBreak",
          "DuplicateHandle",
          "CloseHandle",
          "FlsAlloc",
          "FlsFree",
          "FlsSetValue",
          "FlsGetValue",
          "EventSetInformation",
          "EventUnregister",
          "EventRegister",
          "EventProviderEnabled",
          "EventWriteTransfer",
          "WindowsDuplicateString",
          "WindowsStringHasEmbeddedNull",
          "WindowsCreateStringReference",
          "WindowsGetStringRawBuffer",
          "WindowsIsStringEmpty",
          "WindowsDeleteString",
          "WindowsCreateString",
          "CoCreateGuid",
          "CoMarshalInterface",
          "CoTaskMemAlloc",
          "CoTaskMemFree",
          "CoResumeClassObjects",
          "CoRegisterClassObject",
          "CoTaskMemRealloc",
          "CoDecrementMTAUsage",
          "CoRevokeClassObject",
          "PropVariantClear",
          "CoReleaseServerProcess",
          "CreateStreamOnHGlobal",
          "CoWaitForMultipleObjects",
          "CoInitializeSecurity",
          "CoIncrementMTAUsage",
          "CoImpersonateClient",
          "CoGetCallContext",
          "CoRevertToSelf",
          "CoAddRefServerProcess",
          "CoReleaseMarshalData",
          "CoCreateFreeThreadedMarshaler",
          "CoCreateInstance",
          "StringFromGUID2",
          "Sleep",
          "InitializeConditionVariable",
          "WakeConditionVariable",
          "WakeAllConditionVariable",
          "InitOnceExecuteOnce",
          "SleepConditionVariableCS",
          "SleepConditionVariableSRW",
          "RoUninitialize",
          "RoActivateInstance",
          "RoRegisterActivationFactories",
          "RoInitialize",
          "RoRevokeActivationFactories",
          "RoGetActivationFactory",
          "RoOriginateError",
          "RoOriginateErrorW",
          "SetRestrictedErrorInfo",
          "RoTransformError",
          "GetRestrictedErrorInfo",
          "DecodePointer",
          "EncodePointer",
          "WideCharToMultiByte",
          "CompareStringOrdinal",
          "MultiByteToWideChar",
          "GetStringTypeW",
          "QueryPerformanceCounter",
          "GetSystemTimePreciseAsFileTime",
          "GetTickCount",
          "GetVersionExW",
          "GetSystemInfo",
          "GetSystemTimeAsFileTime",
          "GetSystemDirectoryW",
          "InitializeSListHead",
          "ord69",
          "___lc_locale_name_func",
          "_configthreadlocale",
          "___mb_cur_max_func",
          "setlocale",
          "_lock_locales",
          "_unlock_locales",
          "___lc_codepage_func",
          "__pctype_func",
          "localeconv",
          "_itow_s",
          "wcstoll",
          "wcstoull",
          "_i64toa_s",
          "wcstol",
          "wcstod",
          "_ui64tow_s",
          "_i64tow_s",
          "_ui64toa_s",
          "_lock_file",
          "_unlock_file",
          "ceilf",
          "ceil",
          "log2",
          "frexp",
          "rand_s",
          "BCryptDestroyHash",
          "BCryptFinishHash",
          "BCryptCreateHash",
          "BCryptHashData",
          "BCryptOpenAlgorithmProvider",
          "BCryptCloseAlgorithmProvider",
          "BCryptGenRandom",
          "PathFindFileNameW",
          "PathFileExistsW",
          "CreateFiberEx",
          "GetDriveTypeW",
          "DeleteFileW",
          "CreateFileW",
          "FindNextFileW",
          "FindClose",
          "GetFinalPathNameByHandleW",
          "GetLongPathNameW",
          "GetFileAttributesW",
          "SetEndOfFile",
          "SetFilePointerEx",
          "FindFirstFileW",
          "GetFileSizeEx",
          "IsThreadAFiber",
          "CryptUnprotectData",
          "CertGetCertificateContextProperty",
          "CryptFindOIDInfo",
          "CryptMsgGetParam",
          "CryptProtectData",
          "CertFreeCertificateContext",
          "CertVerifyCertificateChainPolicy",
          "CryptBinaryToStringW",
          "CertFreeCertificateChain",
          "CertGetNameStringW",
          "CryptStringToBinaryW",
          "CertGetCertificateChain",
          "RoGetAgileReference",
          "GetProcessMitigationPolicy",
          "OpenProcess",
          "GetTokenInformation",
          "RevertToSelf",
          "ImpersonateLoggedOnUser",
          "GetLengthSid",
          "CopySid",
          "SetThreadpoolTimer",
          "WaitForThreadpoolTimerCallbacks",
          "SubmitThreadpoolWork",
          "CloseThreadpoolTimer",
          "CreateThreadpoolTimer",
          "CreateThreadpoolWork",
          "CloseThreadpoolWork",
          "WaitForThreadpoolWorkCallbacks",
          "SetThreadpoolThreadMaximum",
          "CreateThreadpool",
          "CloseThreadpool",
          "TraceMessage",
          "PathCchStripToRoot",
          "PathAllocCanonicalize",
          "PathCchRemoveFileSpec",
          "PathAllocCombine",
          "PathCchIsRoot",
          "PathCchFindExtension",
          "LocalFree",
          "LocalAlloc",
          "QueryFullProcessImageNameW",
          "htons",
          "ntohs",
          "RegQueryValueExW",
          "RegCloseKey",
          "RegGetValueW",
          "RegOpenCurrentUser",
          "RegOpenKeyExW",
          "RegSetKeyValueW",
          "ExpandEnvironmentStringsW",
          "GetFileVersionInfoW",
          "GetFileVersionInfoSizeW",
          "VerQueryValueW",
          "MapViewOfFile",
          "CreateFileMappingW",
          "UnmapViewOfFile",
          "OpenFileMappingW",
          "LookupAccountSidW",
          "ConvertSidToStringSidW",
          "FindResourceW",
          "RoGetBufferMarshaler",
          "ord290",
          "SHTaskPoolAllowThreadReuse",
          "SHTaskPoolQueueTask",
          "AllowSetForegroundWindow",
          "CreateStreamOverRandomAccessStream",
          "PathIsURLW",
          "GetPackagesByPackageFamily",
          "GetPackageFullName",
          "WTGetSignatureInfo",
          "WTHelperGetProvSignerFromChain",
          "WinVerifyTrust",
          "WTHelperProvDataFromStateData",
          "ResolveDelayLoadedAPI",
          "DelayLoadFailureHook",
          "ApiSetQueryApiSetPresence"
        ],
        "libraries": [
          "api-ms-win-crt-runtime-l1-1-0.dll",
          "api-ms-win-crt-stdio-l1-1-0.dll",
          "api-ms-win-crt-string-l1-1-0.dll",
          "api-ms-win-crt-heap-l1-1-0.dll",
          "ntdll.dll",
          "api-ms-win-core-fibers-l2-1-0.dll",
          "api-ms-win-core-libraryloader-l1-2-0.dll",
          "api-ms-win-core-synch-l1-1-0.dll",
          "api-ms-win-core-heap-l1-1-0.dll",
          "api-ms-win-core-errorhandling-l1-1-0.dll",
          "api-ms-win-core-processthreads-l1-1-0.dll",
          "api-ms-win-core-localization-l1-2-0.dll",
          "api-ms-win-core-debug-l1-1-0.dll",
          "api-ms-win-core-handle-l1-1-0.dll",
          "api-ms-win-core-fibers-l1-1-0.dll",
          "api-ms-win-eventing-provider-l1-1-0.dll",
          "api-ms-win-core-winrt-string-l1-1-0.dll",
          "api-ms-win-core-com-l1-1-0.dll",
          "api-ms-win-core-synch-l1-2-0.dll",
          "api-ms-win-core-winrt-l1-1-0.dll",
          "api-ms-win-core-winrt-error-l1-1-0.dll",
          "api-ms-win-core-util-l1-1-0.dll",
          "api-ms-win-core-string-l1-1-0.dll",
          "api-ms-win-core-profile-l1-1-0.dll",
          "api-ms-win-core-sysinfo-l1-2-0.dll",
          "api-ms-win-core-sysinfo-l1-1-0.dll",
          "api-ms-win-core-interlocked-l1-1-0.dll",
          "combase.dll",
          "api-ms-win-crt-locale-l1-1-0.dll",
          "api-ms-win-crt-convert-l1-1-0.dll",
          "api-ms-win-crt-filesystem-l1-1-0.dll",
          "api-ms-win-crt-math-l1-1-0.dll",
          "api-ms-win-crt-utility-l1-1-0.dll",
          "bcrypt.dll",
          "api-ms-win-core-shlwapi-legacy-l1-1-0.dll",
          "api-ms-win-core-fibers-l2-1-1.dll",
          "api-ms-win-core-file-l1-1-0.dll",
          "api-ms-win-core-fibers-l1-1-1.dll",
          "CRYPT32.dll",
          "api-ms-win-core-com-l1-1-1.dll",
          "api-ms-win-core-processthreads-l1-1-1.dll",
          "api-ms-win-security-base-l1-1-0.dll",
          "api-ms-win-core-threadpool-l1-2-0.dll",
          "api-ms-win-eventing-classicprovider-l1-1-0.dll",
          "api-ms-win-core-path-l1-1-0.dll",
          "api-ms-win-core-heap-l2-1-0.dll",
          "api-ms-win-core-psapi-l1-1-0.dll",
          "WS2_32.dll",
          "api-ms-win-core-registry-l1-1-0.dll",
          "api-ms-win-core-registry-l1-1-1.dll",
          "api-ms-win-core-processenvironment-l1-1-0.dll",
          "api-ms-win-core-version-l1-1-1.dll",
          "api-ms-win-core-version-l1-1-0.dll",
          "api-ms-win-core-memory-l1-1-0.dll",
          "api-ms-win-security-lsalookup-l2-1-0.dll",
          "api-ms-win-security-sddl-l1-1-0.dll",
          "api-ms-win-core-libraryloader-l1-2-1.dll",
          "api-ms-win-core-winrt-robuffer-l1-1-0.dll",
          "api-ms-win-shell-shdirectory-l1-1-0.dll",
          "api-ms-win-shcore-taskpool-l1-1-0.dll",
          "api-ms-win-rtcore-ntuser-window-l1-1-0.dll",
          "api-ms-win-shcore-stream-winrt-l1-1-0.dll",
          "api-ms-win-core-url-l1-1-0.dll",
          "api-ms-win-appmodel-runtime-l1-1-0.dll",
          "WINTRUST.dll",
          "api-ms-win-core-delayload-l1-1-1.dll",
          "api-ms-win-core-delayload-l1-1-0.dll",
          "api-ms-win-core-apiquery-l1-1-0.dll"
        ],
        "table": [
          {
            "library": "api-ms-win-crt-runtime-l1-1-0.dll",
            "symbols": [
              "_c_exit",
              "_register_thread_local_exe_atexit_callback",
              "_initialize_onexit_table",
              "__p___wargv",
              "_seh_filter_exe",
              "_crt_atexit",
              "_set_app_type",
              "_beginthreadex",
              "_cexit",
              "_configure_wide_argv",
              "__p___argc",
              "_register_onexit_function",
              "_initialize_wide_environment",
              "_get_initial_wide_environment",
              "abort",
              "_initterm",
              "_exit",
              "terminate",
              "_invalid_parameter_noinfo_noreturn",
              "_initterm_e",
              "_errno",
              "exit",
              "_invalid_parameter_noinfo"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-stdio-l1-1-0.dll",
            "symbols": [
              "__stdio_common_vswprintf_s",
              "__stdio_common_vsnwprintf_s",
              "fflush",
              "ungetc",
              "fseek",
              "_wfsopen",
              "fgetc",
              "fclose",
              "_get_stream_buffer_pointers",
              "__stdio_common_vsnprintf_s",
              "__stdio_common_vswprintf",
              "__stdio_common_vsprintf_s",
              "fputc",
              "fread",
              "__p__commode",
              "fwrite",
              "fgetpos",
              "_fseeki64",
              "fsetpos",
              "_set_fmode",
              "setvbuf"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-string-l1-1-0.dll",
            "symbols": [
              "toupper",
              "iswxdigit",
              "iswascii",
              "strcpy_s",
              "_wcsicmp",
              "strnlen",
              "iswdigit",
              "wcsnlen",
              "iswlower",
              "_stricmp",
              "iswspace",
              "towlower",
              "iswupper",
              "isxdigit",
              "strcspn",
              "_wcsdup",
              "isupper",
              "tolower",
              "__strncnt",
              "wcscmp",
              "islower"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-heap-l1-1-0.dll",
            "symbols": [
              "_malloc_base",
              "_callnewh",
              "realloc",
              "calloc",
              "_free_base",
              "free",
              "_set_new_mode",
              "_calloc_base",
              "malloc"
            ],
            "type": "import"
          },
          {
            "library": "ntdll.dll",
            "symbols": [
              "RtlFreeHeap",
              "RtlUnwindEx",
              "RtlLookupFunctionEntry",
              "RtlPcToFileHeader",
              "RtlGetDeviceFamilyInfoEnum",
              "RtlGetVersion",
              "RtlIpv4StringToAddressExW",
              "RtlIpv6StringToAddressExW",
              "RtlIpv4AddressToStringExW",
              "RtlIpv6AddressToStringExW",
              "NtCreateSection",
              "NtQuerySection"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-fibers-l2-1-0.dll",
            "symbols": [
              "ConvertFiberToThread",
              "ConvertThreadToFiber",
              "SwitchToFiber",
              "DeleteFiber"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-libraryloader-l1-2-0.dll",
            "symbols": [
              "GetModuleHandleExW",
              "GetModuleHandleA",
              "GetProcAddress",
              "GetModuleHandleW",
              "GetModuleFileNameW",
              "LoadLibraryExW",
              "GetModuleFileNameA",
              "FreeLibrary",
              "SizeofResource",
              "LockResource",
              "LoadResource"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-synch-l1-1-0.dll",
            "symbols": [
              "CreateMutexW",
              "InitializeSRWLock",
              "AcquireSRWLockExclusive",
              "TryAcquireSRWLockExclusive",
              "EnterCriticalSection",
              "OpenSemaphoreW",
              "ReleaseSemaphore",
              "WaitForSingleObject",
              "ResetEvent",
              "WaitForSingleObjectEx",
              "CreateMutexExW",
              "ReleaseSRWLockExclusive",
              "ReleaseMutex",
              "SetEvent",
              "LeaveCriticalSection",
              "InitializeCriticalSectionEx",
              "CreateEventExW",
              "DeleteCriticalSection",
              "InitializeCriticalSectionAndSpinCount",
              "CreateSemaphoreExW",
              "ReleaseSRWLockShared",
              "AcquireSRWLockShared"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-heap-l1-1-0.dll",
            "symbols": [
              "GetProcessHeap",
              "HeapAlloc",
              "HeapFree"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-errorhandling-l1-1-0.dll",
            "symbols": [
              "GetLastError",
              "RaiseException",
              "SetLastError"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-processthreads-l1-1-0.dll",
            "symbols": [
              "GetProcessId",
              "GetCurrentThread",
              "OpenThreadToken",
              "GetProcessTimes",
              "GetCurrentThreadId",
              "OpenProcessToken",
              "GetExitCodeThread",
              "GetCurrentProcessId",
              "GetCurrentProcess"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-localization-l1-2-0.dll",
            "symbols": [
              "IdnToAscii",
              "GetThreadPreferredUILanguages",
              "GetLocaleInfoEx",
              "LCMapStringEx",
              "GetUserPreferredUILanguages",
              "GetSystemPreferredUILanguages",
              "SetThreadPreferredUILanguages",
              "FormatMessageW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-debug-l1-1-0.dll",
            "symbols": [
              "OutputDebugStringW",
              "IsDebuggerPresent",
              "DebugBreak"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-handle-l1-1-0.dll",
            "symbols": [
              "DuplicateHandle",
              "CloseHandle"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-fibers-l1-1-0.dll",
            "symbols": [
              "FlsAlloc",
              "FlsFree",
              "FlsSetValue",
              "FlsGetValue"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-eventing-provider-l1-1-0.dll",
            "symbols": [
              "EventSetInformation",
              "EventUnregister",
              "EventRegister",
              "EventProviderEnabled",
              "EventWriteTransfer"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-winrt-string-l1-1-0.dll",
            "symbols": [
              "WindowsDuplicateString",
              "WindowsStringHasEmbeddedNull",
              "WindowsCreateStringReference",
              "WindowsGetStringRawBuffer",
              "WindowsIsStringEmpty",
              "WindowsDeleteString",
              "WindowsCreateString"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-com-l1-1-0.dll",
            "symbols": [
              "CoCreateGuid",
              "CoMarshalInterface",
              "CoTaskMemAlloc",
              "CoTaskMemFree",
              "CoResumeClassObjects",
              "CoRegisterClassObject",
              "CoTaskMemRealloc",
              "CoDecrementMTAUsage",
              "CoRevokeClassObject",
              "PropVariantClear",
              "CoReleaseServerProcess",
              "CreateStreamOnHGlobal",
              "CoWaitForMultipleObjects",
              "CoInitializeSecurity",
              "CoIncrementMTAUsage",
              "CoImpersonateClient",
              "CoGetCallContext",
              "CoRevertToSelf",
              "CoAddRefServerProcess",
              "CoReleaseMarshalData",
              "CoCreateFreeThreadedMarshaler",
              "CoCreateInstance",
              "StringFromGUID2"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-synch-l1-2-0.dll",
            "symbols": [
              "Sleep",
              "InitializeConditionVariable",
              "WakeConditionVariable",
              "WakeAllConditionVariable",
              "InitOnceExecuteOnce",
              "SleepConditionVariableCS",
              "SleepConditionVariableSRW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-winrt-l1-1-0.dll",
            "symbols": [
              "RoUninitialize",
              "RoActivateInstance",
              "RoRegisterActivationFactories",
              "RoInitialize",
              "RoRevokeActivationFactories",
              "RoGetActivationFactory"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-winrt-error-l1-1-0.dll",
            "symbols": [
              "RoOriginateError",
              "RoOriginateErrorW",
              "SetRestrictedErrorInfo",
              "RoTransformError",
              "GetRestrictedErrorInfo"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-util-l1-1-0.dll",
            "symbols": [
              "DecodePointer",
              "EncodePointer"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-string-l1-1-0.dll",
            "symbols": [
              "WideCharToMultiByte",
              "CompareStringOrdinal",
              "MultiByteToWideChar",
              "GetStringTypeW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-profile-l1-1-0.dll",
            "symbols": [
              "QueryPerformanceCounter"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-sysinfo-l1-2-0.dll",
            "symbols": [
              "GetSystemTimePreciseAsFileTime"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-sysinfo-l1-1-0.dll",
            "symbols": [
              "GetTickCount",
              "GetVersionExW",
              "GetSystemInfo",
              "GetSystemTimeAsFileTime",
              "GetSystemDirectoryW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-interlocked-l1-1-0.dll",
            "symbols": [
              "InitializeSListHead"
            ],
            "type": "import"
          },
          {
            "library": "combase.dll",
            "symbols": [
              "ord69"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-locale-l1-1-0.dll",
            "symbols": [
              "___lc_locale_name_func",
              "_configthreadlocale",
              "___mb_cur_max_func",
              "setlocale",
              "_lock_locales",
              "_unlock_locales",
              "___lc_codepage_func",
              "__pctype_func",
              "localeconv"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-convert-l1-1-0.dll",
            "symbols": [
              "_itow_s",
              "wcstoll",
              "wcstoull",
              "_i64toa_s",
              "wcstol",
              "wcstod",
              "_ui64tow_s",
              "_i64tow_s",
              "_ui64toa_s"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-filesystem-l1-1-0.dll",
            "symbols": [
              "_lock_file",
              "_unlock_file"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-math-l1-1-0.dll",
            "symbols": [
              "ceilf",
              "ceil",
              "log2",
              "frexp"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-crt-utility-l1-1-0.dll",
            "symbols": [
              "rand_s"
            ],
            "type": "import"
          },
          {
            "library": "bcrypt.dll",
            "symbols": [
              "BCryptDestroyHash",
              "BCryptFinishHash",
              "BCryptCreateHash",
              "BCryptHashData",
              "BCryptOpenAlgorithmProvider",
              "BCryptCloseAlgorithmProvider",
              "BCryptGenRandom"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-shlwapi-legacy-l1-1-0.dll",
            "symbols": [
              "PathFindFileNameW",
              "PathFileExistsW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-fibers-l2-1-1.dll",
            "symbols": [
              "CreateFiberEx"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-file-l1-1-0.dll",
            "symbols": [
              "GetDriveTypeW",
              "DeleteFileW",
              "CreateFileW",
              "FindNextFileW",
              "FindClose",
              "GetFinalPathNameByHandleW",
              "GetLongPathNameW",
              "GetFileAttributesW",
              "SetEndOfFile",
              "SetFilePointerEx",
              "FindFirstFileW",
              "GetFileSizeEx"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-fibers-l1-1-1.dll",
            "symbols": [
              "IsThreadAFiber"
            ],
            "type": "import"
          },
          {
            "library": "CRYPT32.dll",
            "symbols": [
              "CryptUnprotectData",
              "CertGetCertificateContextProperty",
              "CryptFindOIDInfo",
              "CryptMsgGetParam",
              "CryptProtectData",
              "CertFreeCertificateContext",
              "CertVerifyCertificateChainPolicy",
              "CryptBinaryToStringW",
              "CertFreeCertificateChain",
              "CertGetNameStringW",
              "CryptStringToBinaryW",
              "CertGetCertificateChain"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-com-l1-1-1.dll",
            "symbols": [
              "RoGetAgileReference"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-processthreads-l1-1-1.dll",
            "symbols": [
              "GetProcessMitigationPolicy",
              "OpenProcess"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-security-base-l1-1-0.dll",
            "symbols": [
              "GetTokenInformation",
              "RevertToSelf",
              "ImpersonateLoggedOnUser",
              "GetLengthSid",
              "CopySid"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-threadpool-l1-2-0.dll",
            "symbols": [
              "SetThreadpoolTimer",
              "WaitForThreadpoolTimerCallbacks",
              "SubmitThreadpoolWork",
              "CloseThreadpoolTimer",
              "CreateThreadpoolTimer",
              "CreateThreadpoolWork",
              "CloseThreadpoolWork",
              "WaitForThreadpoolWorkCallbacks",
              "SetThreadpoolThreadMaximum",
              "CreateThreadpool",
              "CloseThreadpool"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-eventing-classicprovider-l1-1-0.dll",
            "symbols": [
              "TraceMessage"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-path-l1-1-0.dll",
            "symbols": [
              "PathCchStripToRoot",
              "PathAllocCanonicalize",
              "PathCchRemoveFileSpec",
              "PathAllocCombine",
              "PathCchIsRoot",
              "PathCchFindExtension"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-heap-l2-1-0.dll",
            "symbols": [
              "LocalFree",
              "LocalAlloc"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-psapi-l1-1-0.dll",
            "symbols": [
              "QueryFullProcessImageNameW"
            ],
            "type": "import"
          },
          {
            "library": "WS2_32.dll",
            "symbols": [
              "htons",
              "ntohs"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-registry-l1-1-0.dll",
            "symbols": [
              "RegQueryValueExW",
              "RegCloseKey",
              "RegGetValueW",
              "RegOpenCurrentUser",
              "RegOpenKeyExW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-registry-l1-1-1.dll",
            "symbols": [
              "RegSetKeyValueW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-processenvironment-l1-1-0.dll",
            "symbols": [
              "ExpandEnvironmentStringsW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-version-l1-1-1.dll",
            "symbols": [
              "GetFileVersionInfoW",
              "GetFileVersionInfoSizeW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-version-l1-1-0.dll",
            "symbols": [
              "VerQueryValueW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-memory-l1-1-0.dll",
            "symbols": [
              "MapViewOfFile",
              "CreateFileMappingW",
              "UnmapViewOfFile",
              "OpenFileMappingW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-security-lsalookup-l2-1-0.dll",
            "symbols": [
              "LookupAccountSidW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-security-sddl-l1-1-0.dll",
            "symbols": [
              "ConvertSidToStringSidW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-libraryloader-l1-2-1.dll",
            "symbols": [
              "FindResourceW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-winrt-robuffer-l1-1-0.dll",
            "symbols": [
              "RoGetBufferMarshaler"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-shell-shdirectory-l1-1-0.dll",
            "symbols": [
              "ord290"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-shcore-taskpool-l1-1-0.dll",
            "symbols": [
              "SHTaskPoolAllowThreadReuse",
              "SHTaskPoolQueueTask"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-rtcore-ntuser-window-l1-1-0.dll",
            "symbols": [
              "AllowSetForegroundWindow"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-shcore-stream-winrt-l1-1-0.dll",
            "symbols": [
              "CreateStreamOverRandomAccessStream"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-url-l1-1-0.dll",
            "symbols": [
              "PathIsURLW"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-appmodel-runtime-l1-1-0.dll",
            "symbols": [
              "GetPackagesByPackageFamily",
              "GetPackageFullName"
            ],
            "type": "import"
          },
          {
            "library": "WINTRUST.dll",
            "symbols": [
              "WTGetSignatureInfo",
              "WTHelperGetProvSignerFromChain",
              "WinVerifyTrust",
              "WTHelperProvDataFromStateData"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-delayload-l1-1-1.dll",
            "symbols": [
              "ResolveDelayLoadedAPI"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-delayload-l1-1-0.dll",
            "symbols": [
              "DelayLoadFailureHook"
            ],
            "type": "import"
          },
          {
            "library": "api-ms-win-core-apiquery-l1-1-0.dll",
            "symbols": [
              "ApiSetQueryApiSetPresence"
            ],
            "type": "import"
          }
        ]
      },
      "total": {
        "libraries": 68,
        "resources": 3,
        "sections": 7,
        "symbols": 68
      }
    },
    "yara": {
      "elapsed": 0.000234,
      "flags": [
        "compiling_error"
      ]
    }
  }
}```

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings