### PR TITLE
Hotfix exiftool update 12.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2021-06-23
+### Changed
+- Updated `exiftool` from version `12.25` to `12.28`
+
 ## 2021-06-15
 ### Added
 - Default YARA volume mount and placeholder test YARA rule to verify ScanYARA functionality. (@Derekt2)

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get -qq update && \
     jq && \
 # Download and compile exiftool
     cd /tmp/ && \
-    curl -OL https://exiftool.org/Image-ExifTool-12.25.tar.gz && \
-    tar -zxvf Image-ExifTool-12.25.tar.gz && \
-    cd Image-ExifTool-12.25/ && \
+    curl -OL https://exiftool.org/Image-ExifTool-12.28.tar.gz && \
+    tar -zxvf Image-ExifTool-12.28.tar.gz && \
+    cd Image-ExifTool-12.28/ && \
     perl Makefile.PL && \
     make && \
     make install && \


### PR DESCRIPTION
**Describe the change**
Exiftool version 12.25 was removed by the vendor and was causing new builds of Strelka to fail. Updating to the latest version (12.28) fixes this issue.

**Describe testing procedures**
Updated exiftool, built Strelka, and scanned file with exiftool scanner.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
