### PR TITLE
Adding John the Ripper for Dictionary attacks & Option for Bruteforcing.

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -74,6 +74,20 @@ RUN apt-get -qq update && \
     python3 setup.py build --dynamic-linking && \
     python3 setup.py install
 
+
+# Install JTR
+RUN apt-get -qq update \
+  && apt-get install -qq --no-install-recommends -y git python build-essential ca-certificates libssl-dev zlib1g-dev yasm libgmp-dev libpcap-dev libbz2-dev libgomp1
+RUN git clone https://github.com/magnumripper/JohnTheRipper.git /jtr \
+  && rm -rf /jtr/.git \
+  && cd /jtr/src \
+  && ./configure \
+  && make -s clean \
+  && make -sj4 \
+  && make install \
+  && cp -Tr /jtr/run/ /jtr && rm -rf /jtr/run \
+  && chmod -R 777 /jtr
+
 # Install Python packages
 COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
 RUN pip3 install --no-cache-dir -r /strelka/requirements.txt && \

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -70,8 +70,23 @@ scanners:
   'ScanEncryptedDoc':
     - positive:
         flavors:
-          - 'application/encrypted'
+          - 'encrypted_word_document'
       priority: 5
+      options:
+        max_length: 5
+        scanner_timeout: 150
+        log_pws: True
+        # brute_force: True
+  'ScanEncryptedZip':
+    - positive:
+        flavors:
+          - 'encrypted_zip'
+      priority: 5
+      options:
+        max_length: 5
+        scanner_timeout: 150
+        log_pws: True
+        # brute_force: True
   'ScanEntropy':
     - positive:
         flavors:

--- a/configs/python/backend/taste/taste.yara
+++ b/configs/python/backend/taste/taste.yara
@@ -49,6 +49,39 @@ rule cpio_file {
         $a at 0
 }
 
+
+rule encrypted_zip
+{
+    meta:
+        author = "thudak@korelogic.com"
+        comment = "Solution 7 - encrypted zip file"
+
+    strings:
+        $local_file = { 50 4b 03 04 }
+
+    condition:
+        // look for the ZIP header
+        uint32(0) == 0x04034b50 and
+        // make sure we have a local file header
+        $local_file and
+        // go through each local file header and see if the encrypt bits are set
+        for any i in (1..#local_file): (uint16(@local_file[i]+6) & 0x1 == 0x1)		
+}
+
+rule encrypted_word_document
+{
+    meta:
+        author = "Derek Thomas"
+    strings:
+        $ = "EncryptionInfo" wide
+        $ = "Microsoft.Container.EncryptionTransform" wide
+        $ = "StrongEncryptionDataSpace" wide
+        $ = "StrongEncryptionTransform" wide
+    condition:
+        uint32be(0) == 0xd0cf11e0 and
+        any of them		
+}
+
 rule iso_file {
     meta:
         type = "archive"

--- a/src/python/strelka/scanners/scan_encrypted_doc.py
+++ b/src/python/strelka/scanners/scan_encrypted_doc.py
@@ -1,64 +1,116 @@
 import io
 import os
 import msoffcrypto
+import subprocess
+import tempfile
 
 from strelka import strelka
 
+def crack_word(self, data, jtr_path, tmp_dir, password_file, max_length=10, scanner_timeout=150, brute=False):
+	try:
+		with tempfile.NamedTemporaryFile(dir=tmp_dir, mode='wb') as tmp_data:
+			tmp_data.write(data)
+			tmp_data.flush()
+			
+			(office2john, stderr) = subprocess.Popen(
+				[jtr_path+'office2john.py', tmp_data.name],
+				stdout=subprocess.PIPE,
+				stderr=subprocess.DEVNULL
+			).communicate()
+		
+		with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_data:
+			tmp_data.write(office2john)
+			tmp_data.flush()
+
+			(stdout, stderr) = subprocess.Popen(
+				[jtr_path+'john', '--show', tmp_data.name],
+				stdout=subprocess.PIPE,
+				stderr=subprocess.DEVNULL
+			).communicate()
+
+		if b"0 password hashes cracked" in stdout:
+
+			with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_data:
+				tmp_data.write(office2john)
+				tmp_data.flush()
+			
+				if os.path.isfile(password_file):
+					(stdout, stderr) = subprocess.Popen(
+						[jtr_path+'john', f'-w={password_file}', tmp_data.name],
+						stdout=subprocess.PIPE,
+						stderr=subprocess.DEVNULL
+					).communicate(timeout=scanner_timeout)
+					
+					if stdout.split(b'\n')[3]:
+						self.flags.append('cracked_by_wordlist')
+						return stdout.split(b'\n')[3].split()[0]
+
+				if brute:
+					(stdout, stderr) = subprocess.Popen(
+						[jtr_path+'john', '--incremental=Alnum', f'--max-length={max_length}', f'--max-run-time={scanner_timeout}', tmp_data.name],
+						stdout=subprocess.PIPE,
+						stderr=subprocess.DEVNULL
+					).communicate(timeout=scanner_timeout)
+					if stdout.split(b'\n')[3]:
+						self.flags.append('cracked_by_incremental')
+						return stdout.split(b'\n')[3].split()[0]
+				return ''
+		else:
+			return stdout.split(b':')[1].split()[0]
+
+	except Exception as e:
+		self.flags.append(str(e))
+		return ''
 
 class ScanEncryptedDoc(strelka.Scanner):
+	"""Extracts passwords from encrypted office word documents.
 
-    def init(self):
-        self.passwords = []
+	Attributes:
+		passwords: List of passwords to use when bruteforcing encrypted files.
 
-    def scan(self, data, file, options, expire_at):
-        password_file = options.get('password_file', '/etc/strelka/passwords.dat')
+	Options:
+		limit: Maximum number of files to extract.
+			Defaults to 1000.
+		password_file: Location of passwords file for zip archives.
+			Defaults to /etc/strelka/passwords.dat.
+	"""
+	def scan(self, data, file, options, expire_at):
+		
+		jtr_path = options.get('jtr_path', '/jtr/')
+		tmp_directory = options.get('tmp_file_directory', '/tmp/')
+		file_limit = options.get('limit', 1000)
+		password_file = options.get('password_file', '/etc/strelka/passwords.dat')
+		log_extracted_pws = options.get('log_pws', True)
+		scanner_timeout = options.get('scanner_timeout', 150)
+		brute = options.get('brute_force', False)
+		max_length = options.get('max_length', 5)
 
-        if not self.passwords:
-            if os.path.isfile(password_file):
-                with open(password_file, 'rb') as f:
-                    for line in f:
-                        self.passwords.append(line.strip())
+		with io.BytesIO(data) as doc_io:
 
-        with io.BytesIO(data) as doc_io:
+			msoff_doc = msoffcrypto.OfficeFile(doc_io)
+			output_doc = io.BytesIO()
+			if extracted_pw := crack_word(self, data, jtr_path, tmp_directory, brute=brute, scanner_timeout=scanner_timeout, max_length=max_length, password_file=password_file):
+				self.event['cracked_password'] = extracted_pw
+				try:
+					msoff_doc.load_key(password=extracted_pw.decode('utf-8'))
+					msoff_doc.decrypt(output_doc)
+					output_doc.seek(0)
+					extract_data = output_doc.read()
+					output_doc.seek(0)
+					extract_file = strelka.File(
+					source=self.name,
+					)
 
-            msoff_doc = msoffcrypto.OfficeFile(doc_io)
-            output_doc = io.BytesIO()
-            password = ''
-            extract_data = b''
+					for c in strelka.chunk_string(extract_data):
+						self.upload_to_coordinator(
+							extract_file.pointer,
+							c,
+							expire_at,
+						)
 
-            if msoff_doc.is_encrypted():             
-                self.flags.append('password_protected')
-                
-                for pw in self.passwords:
-                    if not password:
-                        try:
-                            msoff_doc.load_key(password=pw.decode('utf-8'))
-                            output_doc.seek(0)
-                            msoff_doc.decrypt(output_doc)
-                            output_doc.seek(0)
+					self.files.append(extract_file)
+				except:
+					self.flags.append('Could not decrypt document with recovered password')
 
-                            if output_doc.readable():
-                                extract_data = output_doc.read()
-                                password = pw.decode('utf-8')
-                                break
-
-                        except Exception:
-                            pass
-
-            if password:
-                self.event['password'] = password
-                
-                extract_file = strelka.File(
-                    source=self.name,
-                )
-
-                for c in strelka.chunk_string(extract_data):
-                    self.upload_to_coordinator(
-                        extract_file.pointer,
-                        c,
-                        expire_at,
-                    )
-
-                self.files.append(extract_file)
-            else:
-                self.flags.append('no_password_match_found')
+			else:
+				self.flags.append('Could not extract password')

--- a/src/python/strelka/scanners/scan_encrypted_doc.py
+++ b/src/python/strelka/scanners/scan_encrypted_doc.py
@@ -78,9 +78,8 @@ class ScanEncryptedDoc(strelka.Scanner):
 		
 		jtr_path = options.get('jtr_path', '/jtr/')
 		tmp_directory = options.get('tmp_file_directory', '/tmp/')
-		file_limit = options.get('limit', 1000)
 		password_file = options.get('password_file', '/etc/strelka/passwords.dat')
-		log_extracted_pws = options.get('log_pws', True)
+		log_extracted_pws = options.get('log_pws', False)
 		scanner_timeout = options.get('scanner_timeout', 150)
 		brute = options.get('brute_force', False)
 		max_length = options.get('max_length', 5)
@@ -90,7 +89,8 @@ class ScanEncryptedDoc(strelka.Scanner):
 			msoff_doc = msoffcrypto.OfficeFile(doc_io)
 			output_doc = io.BytesIO()
 			if extracted_pw := crack_word(self, data, jtr_path, tmp_directory, brute=brute, scanner_timeout=scanner_timeout, max_length=max_length, password_file=password_file):
-				self.event['cracked_password'] = extracted_pw
+				if log_extracted_pws:
+					self.event['cracked_password'] = extracted_pw
 				try:
 					msoff_doc.load_key(password=extracted_pw.decode('utf-8'))
 					msoff_doc.decrypt(output_doc)

--- a/src/python/strelka/scanners/scan_encrypted_zip.py
+++ b/src/python/strelka/scanners/scan_encrypted_zip.py
@@ -82,7 +82,7 @@ class ScanEncryptedZip(strelka.Scanner):
 				tmp_directory = options.get('tmp_file_directory', '/tmp/')
 				file_limit = options.get('limit', 1000)
 				password_file = options.get('password_file', '/etc/strelka/passwords.dat')
-				log_extracted_pws = options.get('log_pws', True)
+				log_extracted_pws = options.get('log_pws', False)
 				scanner_timeout = options.get('scanner_timeout', 150)
 				brute = options.get('brute_force', False)
 				max_length = options.get('max_length', 5)

--- a/src/python/strelka/scanners/scan_encrypted_zip.py
+++ b/src/python/strelka/scanners/scan_encrypted_zip.py
@@ -1,0 +1,138 @@
+import subprocess
+import tempfile
+import io
+import os
+import zipfile
+import zlib
+
+from strelka import strelka
+
+def crack_zip(self, data, jtr_path, tmp_dir, password_file, brute=False, max_length=10, scanner_timeout=150):
+		try:
+				with tempfile.NamedTemporaryFile(dir=tmp_dir, mode='wb') as tmp_data:
+						tmp_data.write(data)
+						tmp_data.flush()
+						
+						(zip2john, stderr) = subprocess.Popen(
+								[jtr_path+'zip2john', tmp_data.name],
+								stdout=subprocess.PIPE,
+								stderr=subprocess.DEVNULL
+						).communicate()
+				
+				with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_data:
+						tmp_data.write(zip2john)
+						tmp_data.flush()
+
+						(stdout, stderr) = subprocess.Popen(
+								[jtr_path+'john', '--show', tmp_data.name],
+								stdout=subprocess.PIPE,
+								stderr=subprocess.DEVNULL
+						).communicate()
+
+				if b"0 password hashes cracked" in stdout:
+
+						with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_data:
+								tmp_data.write(zip2john)
+								tmp_data.flush()
+						
+								if os.path.isfile(password_file):
+										(stdout, stderr) = subprocess.Popen(
+												[jtr_path+'john', f'-w={password_file}', tmp_data.name],
+												stdout=subprocess.PIPE,
+												stderr=subprocess.DEVNULL
+										).communicate(timeout=scanner_timeout)
+										
+										if stdout.split(b'\n')[1]:
+												self.flags.append('cracked_by_wordlist')
+												return stdout.split(b'\n')[1].split()[0]
+								if brute:
+									(stdout, stderr) = subprocess.Popen(
+											[jtr_path+'john', '--incremental=Alnum', f'--max-length={max_length}', f'--max-run-time={scanner_timeout}', tmp_data.name],
+											stdout=subprocess.PIPE,
+											stderr=subprocess.DEVNULL
+									).communicate(timeout=scanner_timeout)
+									if stdout.split(b'\n')[1]:
+										self.flags.append('cracked_by_incremental')
+										return stdout.split(b'\n')[1].split()[0]
+								return ''
+				else:
+						return stdout.split(b':')[1]
+
+		except Exception as e:
+				self.flags.append(str(e))
+				return ''
+
+
+class ScanEncryptedZip(strelka.Scanner):
+		"""Extracts passwords from encrypted ZIP archives.
+
+		Attributes:
+				passwords: List of passwords to use when bruteforcing encrypted files.
+
+		Options:
+				limit: Maximum number of files to extract.
+						Defaults to 1000.
+				password_file: Location of passwords file for zip archives.
+						Defaults to /etc/strelka/passwords.dat.
+		"""
+
+		def scan(self, data, file, options, expire_at):
+				
+				jtr_path = options.get('jtr_path', '/jtr/')
+				tmp_directory = options.get('tmp_file_directory', '/tmp/')
+				file_limit = options.get('limit', 1000)
+				password_file = options.get('password_file', '/etc/strelka/passwords.dat')
+				log_extracted_pws = options.get('log_pws', True)
+				scanner_timeout = options.get('scanner_timeout', 150)
+				brute = options.get('brute_force', False)
+				max_length = options.get('max_length', 5)
+
+				self.event['total'] = {'files': 0, 'extracted': 0}
+
+				with io.BytesIO(data) as zip_io:
+						try:
+								with zipfile.ZipFile(zip_io) as zip_obj:
+										name_list = zip_obj.namelist()
+										self.event['total']['files'] = len(name_list)
+
+										extracted_pw = crack_zip(self, data, jtr_path, tmp_directory, brute=brute, scanner_timeout=scanner_timeout, max_length=max_length, password_file=password_file)
+										if not extracted_pw:
+												self.flags.append('Could not extract password')
+												return
+										if log_extracted_pws:
+												self.event['cracked_password'] = extracted_pw
+										for i, name in enumerate(name_list):
+												if not name.endswith('/'):
+														if self.event['total']['extracted'] >= file_limit:
+																break
+
+														try:
+																extract_data = zip_obj.read(name, extracted_pw)
+
+																if extract_data:
+																		extract_file = strelka.File(
+																				name=name,
+																				source=self.name,
+																		)
+
+																		for c in strelka.chunk_string(extract_data):
+																				self.upload_to_coordinator(
+																						extract_file.pointer,
+																						c,
+																						expire_at,
+																				)
+
+																		self.files.append(extract_file)
+																		self.event['total']['extracted'] += 1
+
+														except NotImplementedError:
+																self.flags.append('unsupported_compression')
+														except RuntimeError:
+																self.flags.append('runtime_error')
+														except ValueError:
+																self.flags.append('value_error')
+														except zlib.error:
+																self.flags.append('zlib_error')
+
+						except zipfile.BadZipFile:
+								self.flags.append('bad_zip')


### PR DESCRIPTION
**Describe the change**
Include a summary of the change (with required dependencies), any issues it fixes, and relevant motivation and context.
This PR does 3 major changes:
1. It install john the ripper (latest version) from source into the worker image.
2. It removes the native zip cracking in ScanZip, and removes the native scanEncryptedDocument scanner
3. It uses custom yara rules to detect encrypted zip and word documents, and uses JTR to do a dictionary attack instead of a python loop. It is much more efficient and performant (see testing). It also has the option to do brute force attacks, though these are commented in the backend.yaml by default.

**Describe testing procedures**
Describe the tests that you ran to verify your changes (including test configurations) and instructions so we can reproduce the tests. To assist in testing, the project maintainers may ask for file samples.
All options and zip archives and word documents were tested encrypted and unencrypted. 

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.
for the purpose of testing, real encrypted malware was used md5: 66abfac680f904ac34d2ff63f65f458f for the doc, and c182f6bd7f2590b6927227208a5722fa for the zip.
![image](https://user-images.githubusercontent.com/28223951/129789834-4cf293e6-5163-4c17-abba-3efd0581bbd3.png)
![image](https://user-images.githubusercontent.com/28223951/129789860-5ae2b78e-cdc4-4649-aabc-5e3ddd97eedc.png)


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
