### PR TITLE
Update exiftool to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Changes to the project will be tracked in this file via the date of change.
 
+## 2021-10-04
+### Changed
+- Updated `exiftool` from version `12.28` to `12.30`
+
 ## 2021-06-23
 ### Changed
 - Updated `exiftool` from version `12.25` to `12.28`

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get -qq update && \
     jq && \
 # Download and compile exiftool
     cd /tmp/ && \
-    curl -OL https://exiftool.org/Image-ExifTool-12.28.tar.gz && \
-    tar -zxvf Image-ExifTool-12.28.tar.gz && \
-    cd Image-ExifTool-12.28/ && \
+    curl -OL https://exiftool.org/Image-ExifTool-12.30.tar.gz && \
+    tar -zxvf Image-ExifTool-12.30.tar.gz && \
+    cd Image-ExifTool-12.30/ && \
     perl Makefile.PL && \
     make && \
     make install && \


### PR DESCRIPTION
**Describe the change**
The 12.28 version of exiftools is no longer available, which causes backend builds to fail. This change upgrades to 12.30 which is the latest production release and is available. 12.32 is also available but is not marked a "production release" at this time. 

It also appears the download could rely on metacpan, e.g.: 
https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-12.30.tar.gz

According to the changelog production releases are uploaded to metacpan and I see past production release still available there.

**Describe testing procedures**
Backend build now succeeds. No further testing done. A quick read of the changelog does not suggest any incompatible changes were made.

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
