### PR TITLE
Fix K8S backend configmap yaml

### DIFF
--- a/misc/kubernetes/backend-configmap.yaml
+++ b/misc/kubernetes/backend-configmap.yaml
@@ -42,15 +42,15 @@ data:
               - 'application/x-bzip2'
               - 'bzip2_file'
           priority: 5
-      #'ScanCapa':
-      #  - positive:
-      #      flavors:
-      #        - 'application/x-dosexec'
-      #        - 'mz_file'
-      #    priority: 5
-      #    options:
-      #      tmp_directory: '/dev/shm/'
-      #      location: '/etc/capa/'
+      #  'ScanCapa':
+      #    - positive:
+      #        flavors:
+      #          - 'application/x-dosexec'
+      #          - 'mz_file'
+      #      priority: 5
+      #      options:
+      #        tmp_directory: '/dev/shm/'
+      #        location: '/etc/capa/'
       'ScanDocx':
         - positive:
             flavors:
@@ -164,22 +164,22 @@ data:
               - 'ImageHeight'
               - 'ImageWidth'
             tmp_directory: '/dev/shm/'
-      #'ScanFloss':
-      #  - positive:
-      #      flavors:
-      #        - 'application/x-dosexec'
-      #        - 'mz_file'
-      #    priority: 5
-      #    options:
-      #      tmp_directory: '/dev/shm/'
-      #      limit: 100
-    'ScanFooter':
-      - positive:
-          flavors:
-            - '*'
-        priority: 5
-        options:
-          length: 50
+      #  'ScanFloss':
+      #    - positive:
+      #        flavors:
+      #          - 'application/x-dosexec'
+      #          - 'mz_file'
+      #      priority: 5
+      #      options:
+      #        tmp_directory: '/dev/shm/'
+      #        limit: 100
+      'ScanFooter':
+        - positive:
+            flavors:
+              - '*'
+          priority: 5
+          options:
+            length: 50
       'ScanGif':
         - positive:
             flavors:


### PR DESCRIPTION
Backend reported errors parsing previously.

**Describe the change**
This will allow the instructions on `misc/kubernetes` to be followed without errors on BE startup.

**Describe testing procedures**
1. BE service did not start, reporting yml parse errors.
2. Changes made
3. Service starts and can process files

For a simpler validation, just copy the whole block of YML, before and after change, and try it in a [YML linter](http://www.yamllint.com/).

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
