### PR TITLE
Grpcio arm compilation fix

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -6,8 +6,8 @@ cryptography==3.4.7
 docker==5.0.0
 esprima==4.0.1
 git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (package installed as 'entropy')
-grpcio-tools==1.35.0
-grpcio==1.35.0
+grpcio==1.42.0
+grpcio-tools==1.42.0
 html5lib==1.1
 inflection==0.5.1
 interruptingcow==0.8

--- a/build/python/mmrpc/Dockerfile
+++ b/build/python/mmrpc/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 RUN apt-get -qq update && \
     apt-get install --no-install-recommends -qq \
 # Install build packages
+    build-essential \
     git \
     python3-dev \
     python3-pip \
@@ -28,6 +29,7 @@ RUN cd /strelka/ && \
     rm -rf dist/ strelka.egg-info && \
     pip3 uninstall -y grpcio-tools && \
     apt-get autoremove -qq --purge \
+    build-essential \
     git \
     python3-dev \
     python3-pip \

--- a/build/python/mmrpc/requirements.txt
+++ b/build/python/mmrpc/requirements.txt
@@ -1,4 +1,4 @@
 cryptography==3.3.2
-grpcio==1.27.2
-grpcio-tools==1.27.2
+grpcio==1.42.0
+grpcio-tools==1.42.0
 git+https://github.com/egaus/MaliciousMacroBot


### PR DESCRIPTION
**Describe the change**
This change reflects issue #187, a failure to compile the `mmrpc` image due to a compilation issue with `grpcio`. Adding the `build-essentials` package fixes this issue. 

**Describe testing procedures**
1. Built container (with PyMuPDF removed - PDF Scanner - See #188 for that issue)
2. Allow cluster to run for 10+ minutes while submitting several different filetypes with fileshot. 

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
