### PR TITLE
bugfix: javascript scanner regex

### DIFF
--- a/src/python/strelka/scanners/scan_javascript.py
+++ b/src/python/strelka/scanners/scan_javascript.py
@@ -54,6 +54,6 @@ class ScanJavascript(strelka.Scanner):
             if t.type == 'Identifier':
                 if t.value not in self.event['identifiers']:
                     self.event['identifiers'].append(t.value)
-            if type == 'RegularExpression':
+            if t.type == 'RegularExpression':
                 if t.value not in self.event['regular_expressions']:
                     self.event['regular_expressions'].append(t.value)


### PR DESCRIPTION
**Describe the change**

Fixes a bug in the javascript scanner preventing regular expressions from being added to the scan results.

**Describe testing procedures**

- Created a test file with a regular expression
- Ran fileshot and verified the regular expression is included the strelka.log


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
