### PR TITLE
Use a specific version of JTR (#13)

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -79,7 +79,9 @@ RUN apt-get -qq update && \
 # Install JTR
 RUN apt-get -qq update \
   && apt-get install -qq --no-install-recommends -y git python build-essential ca-certificates libssl-dev zlib1g-dev yasm libgmp-dev libpcap-dev libbz2-dev libgomp1
-RUN git clone https://github.com/magnumripper/JohnTheRipper.git /jtr \
+# The maintainer isn't big on releases or tags so grab an arbitrary, but consistent, commit.
+# Additionally jump through some extra hoops to get the single commit to save some download time.
+RUN mkdir jtr && cd jtr && git init && git remote add origin https://github.com/openwall/john.git && git fetch --depth 1 origin b5c10480f56ff1b5d76c6cbdaf9c817582ee2228 && git reset --hard FETCH_HEAD \
   && rm -rf /jtr/.git \
   && cd /jtr/src \
   && ./configure \


### PR DESCRIPTION
**Describe the change**

* Twice we've seen a build w/ JTR apparently unstable.
  * It's unclear if this is a build issue, or a result of grabbing
a bad version (as we were just grabbing the repo head).
  * This ensures we grab the same commit, so if we continue to see
issues we can go from there.
  * There are no even halfway recent tags so the commit is arbitrary.
* Also changes the repo from magnumripper/JohnTheRipper to openwall/john
as that's where the old repo forwards to.
* And grab a single commit to speed things up (239 MB -> 140 ish MB).

**Describe testing procedures**
I've been running & rebuilding Strelka w/ these changes. This doesn't seem to have resolved JTR build issues but it may remove some possible causes.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
