### PR TITLE
Install Archive library for ExifTools

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -36,6 +36,14 @@ RUN apt-get -qq update && \
     unrar \
     upx \
     jq && \
+# Download and compile Archive library, needed for exiftool to work best
+    cd /tmp/ && \
+    curl -OL https://cpan.metacpan.org/authors/id/P/PH/PHRED/Archive-Zip-1.68.tar.gz && \
+    tar -xzf Archive-Zip-1.68.tar.gz && \
+    cd Archive-Zip-1.68/ && \
+    perl Makefile.PL && \
+    make && \
+    make install && \
 # Download and compile exiftool
     cd /tmp/ && \
     curl -OL https://github.com/exiftool/exiftool/archive/refs/tags/$EXIFTOOL_VERSION.tar.gz && \


### PR DESCRIPTION
**Describe the change**

ExifTools requires a perl library "Archive" to successfully inspect some word documents ([1]). This PR installs the required library in the Docker build.

This thread pretty much describes the symptom and how to fix it: https://exiftool.org/forum/index.php?topic=5087.0


1. Some quick testing suggests `docx` and `docm` files require the extension, but it's probably more complex than that. I have a `doc` file which has the same output before/after the chance, and doesn't include any `zip` fields. 

**Describe testing procedures**

I tested this by just doing docker run on before/after images and then running `exiftool` within.

[Results w/o Archive library](https://gist.github.com/cameron-dunn-sublime/1055bc1482804cebf6868be1e190c206)
[Result w/ Archive library](https://gist.github.com/cameron-dunn-sublime/e062bcf9e9c05bf76839d9bd87e2cae2)

[Test file (a super simple doc)](https://github.com/target/strelka/files/8037747/Test_DocX.docx)

**Sample output**
No direct modification -- some files already looked pretty much identical. Effected file types will have different attributes returned for ScanExifToo.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
