### PR TITLE
Removing ScanQR Debug Logging

### DIFF
--- a/src/python/strelka/scanners/scan_qr.py
+++ b/src/python/strelka/scanners/scan_qr.py
@@ -1,9 +1,13 @@
-from pyzbar.pyzbar import decode
-from PIL import Image
 import io
 import re
+import logging
+
+from pyzbar.pyzbar import decode
+from PIL import Image
 
 from strelka import strelka
+
+logging.getLogger('PIL').setLevel(logging.WARNING)
 
 
 class ScanQr(strelka.Scanner):


### PR DESCRIPTION
**Describe the change**
Updated ScanQR logging to remove `[DEBUG]` statements from outputting on invalid strings.

Before:
```
strelka_backend_1      | 2022-04-26 12:00:59 - [DEBUG] PIL.PngImagePlugin [PngImagePlugin.call]: STREAM b'pHYs' 41 9
strelka_backend_1      | 2022-04-26 12:00:59 - [DEBUG] PIL.PngImagePlugin [PngImagePlugin.call]: STREAM b'IDAT' 62 2975
strelka_backend_1      | 2022-04-26 12:00:59 - [DEBUG] PIL.PngImagePlugin [PngImagePlugin.call]: STREAM b'IHDR' 16 13
strelka_backend_1      | 2022-04-26 12:00:59 - [DEBUG] PIL.PngImagePlugin [PngImagePlugin.call]: STREAM b'pHYs' 41 9
strelka_backend_1      | 2022-04-26 12:00:59 - [DEBUG] PIL.PngImagePlugin [PngImagePlugin.call]: STREAM b'IDAT' 62 20871
```

After:
No `[DEBUG]` statements expected

**Describe testing procedures**
Built PR and tested against various files that reported `[DEBUG]` statements.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
