### PR TITLE
Adding fix for scan elf / logging disable

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -13,7 +13,7 @@ inflection==0.5.1
 interruptingcow==0.8
 jsbeautifier==1.13.13
 libarchive-c==2.9
-lief==0.11.4
+lief==0.12.1
 lxml==4.6.5
 M2Crypto==0.37.1
 nested-lookup==0.2.22

--- a/src/python/strelka/scanners/scan_elf.py
+++ b/src/python/strelka/scanners/scan_elf.py
@@ -1,12 +1,15 @@
+import lief
 from lief import ELF
 
 from strelka import strelka
+
+lief.logging.disable()
 
 
 class ScanElf(strelka.Scanner):
     """Collects metadata from ELF files."""
     def scan(self, data, file, options, expire_at):
-        elf = ELF.parse(raw=data)
+        elf = ELF.parse(raw=list(data))
 
         self.event['total'] = {
             'libraries': len(elf.libraries),
@@ -19,29 +22,32 @@ class ScanElf(strelka.Scanner):
         self.event['nx'] = elf.has_nx
         self.event['pie'] = elf.is_pie
 
-        self.event['header'] = {
-            'endianness': str(elf.header.identity_data).split('.')[1],
-            'entry_point': elf.header.entrypoint,
-            'file': {
-                'type': str(elf.header.file_type).split('.')[1],
-                'version': str(elf.header.object_file_version).split('.')[1],
-            },
-            'flags': {
-                'arm': [str(f).split('.')[1] for f in elf.header.arm_flags_list],
-                'hexagon': [str(f).split('.')[1] for f in elf.header.hexagon_flags_list],
-                'mips': [str(f).split('.')[1] for f in elf.header.mips_flags_list],
-                'ppc64': [str(f).split('.')[1] for f in elf.header.ppc64_flags_list],
-                'processor': elf.header.processor_flag,
-            },
-            'identity': {
-                'class': str(elf.header.identity_class).split('.')[1],
-                'data': str(elf.header.identity_data).split('.')[1],
-                'os_abi': str(elf.header.identity_os_abi).split('.')[1],
-                'version': str(elf.header.identity_version).split('.')[1],
-            },
-            'machine': str(elf.header.machine_type).split('.')[1],
-            'size': elf.header.header_size,
-        }
+        try:
+            self.event['header'] = {
+                'endianness': str(elf.header.identity_data).split('.')[1],
+                'entry_point': elf.header.entrypoint,
+                'file': {
+                    'type': str(elf.header.file_type).split('.')[1],
+                    'version': str(elf.header.object_file_version).split('.')[1],
+                },
+                'flags': {
+                    'arm': [str(f).split('.')[1] for f in elf.header.arm_flags_list],
+                    'hexagon': [str(f).split('.')[1] for f in elf.header.hexagon_flags_list],
+                    'mips': [str(f).split('.')[1] for f in elf.header.mips_flags_list],
+                    'ppc64': [str(f).split('.')[1] for f in elf.header.ppc64_flags_list],
+                    'processor': elf.header.processor_flag,
+                },
+                'identity': {
+                    'class': str(elf.header.identity_class).split('.')[1],
+                    'data': str(elf.header.identity_data).split('.')[1],
+                    'os_abi': str(elf.header.identity_os_abi).split('.')[1],
+                    'version': str(elf.header.identity_version).split('.')[1],
+                },
+                'machine': str(elf.header.machine_type).split('.')[1],
+                'size': elf.header.header_size,
+            }
+        except:
+            pass
 
         if elf.has_interpreter:
             self.event['interpreter'] = elf.interpreter
@@ -75,34 +81,42 @@ class ScanElf(strelka.Scanner):
             self.event['relocations'].append(row)
 
         self.event['sections'] = []
-        for sec in elf.sections:
-            self.event['sections'].append({
-                'alignment': sec.alignment,
-                'entropy': sec.entropy,
-                'flags': [str(f).split('.')[1] for f in sec.flags_list],
-                'name': sec.name,
-                'offset': sec.offset,
-                'size': sec.size,
-                'type': str(sec.type).split('.')[1],
-                'segments': [str(seg.type).split('.')[1] for seg in sec.segments],
-            })
+
+        try:
+            for sec in elf.sections:
+                self.event['sections'].append({
+                    'alignment': sec.alignment,
+                    'entropy': sec.entropy,
+                    'flags': [str(f).split('.')[1] for f in sec.flags_list],
+                    'name': sec.name,
+                    'offset': sec.offset,
+                    'size': sec.size,
+                    'type': str(sec.type).split('.')[1],
+                    'segments': [str(seg.type).split('.')[1] for seg in sec.segments],
+                })
+        except:
+            pass
 
         self.event['segments'] = []
-        for seg in elf.segments:
-            self.event['segments'].append({
-                'alignment': seg.alignment,
-                'file_offset': seg.file_offset,
-                'physical': {
-                    'address': seg.physical_address,
-                    'size': seg.physical_size,
-                },
-                'sections': [str(sec.name).split('.')[1] for sec in seg.sections],
-                'type': str(seg.type).split('.')[1],
-                'virtual': {
-                    'address': seg.virtual_address,
-                    'size': seg.virtual_size,
-                },
-            })
+
+        try:
+            for seg in elf.segments:
+                self.event['segments'].append({
+                    'alignment': seg.alignment,
+                    'file_offset': seg.file_offset,
+                    'physical': {
+                        'address': seg.physical_address,
+                        'size': seg.physical_size,
+                    },
+                    'sections': [str(sec.name).split('.')[1] for sec in seg.sections],
+                    'type': str(seg.type).split('.')[1],
+                    'virtual': {
+                        'address': seg.virtual_address,
+                        'size': seg.virtual_size,
+                    },
+                })
+        except:
+            pass
 
         self.event['symbols'] = {
             'exported': [sym.name for sym in elf.exported_symbols],


### PR DESCRIPTION
**Describe the change**
Fix for ELF implemented to load and parse ELF files. Added in a few try/excepts for sections that I saw threw errors. Removed logging to prevent log flooding.

This was developed to fix the issue noted in #199 

**Describe testing procedures**
With current PR, built and tested against 10+ ELF files.

**Sample output**
```
{
  "file": {
    "depth": 0,
    "flavors": {
      "mime": [
        "application/x-sharedlib"
      ],
      "yara": [
        "elf_file"
      ]
    },
    "scanners": [
      "ScanElf",
      "ScanEntropy",
      "ScanFooter",
      "ScanHash",
      "ScanHeader",
      "ScanYara"
    ],
    "size": 86072,
    "tree": {
      "node": "b79570ba-d6ef-43e3-a9bf-bdbeb88010e5",
      "root": "b79570ba-d6ef-43e3-a9bf-bdbeb88010e5"
    }
  },
  "request": {
    "attributes": {
      "filename": "samples/scan_elf/5c88351017313468b55f8eeae0559c6e6e2b8fd3d7b37b6f6f8ad6232ef763f9"
    },
    "client": "go-fileshot-testing",
    "id": "b79570ba-d6ef-43e3-a9bf-bdbeb88010e5",
    "source": "TEST",
    "time": 1650982282
  },
  "scan": {
    "elf": {
      "elapsed": 0.02187,
      "header": {
        "endianness": "LSB",
        "entry_point": 0,
        "file": {
          "type": "DYNAMIC",
          "version": "CURRENT"
        },
        "flags": {
          "arm": [
            "SOFT_FLOAT",
            "EABI_VER5"
          ],
          "processor": 83886592
        },
        "identity": {
          "class": "CLASS32",
          "data": "LSB",
          "os_abi": "SYSTEMV",
          "version": "CURRENT"
        },
        "machine": "ARM",
        "size": 52
      },
      "nx": true,
      "pie": false,
      "sections": [
        {
          "alignment": 0,
          "entropy": 0,
          "offset": 21096,
          "segments": [
            "LOAD"
          ],
          "size": 0,
          "type": "NULL"
        },
        {
          "alignment": 1,
          "entropy": 3.5766176449086653,
          "flags": [
            "ALLOC"
          ],
          "name": ".interp",
          "offset": 340,
          "segments": [
            "LOAD"
          ],
          "size": 19,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 4.059531433357947,
          "flags": [
            "ALLOC"
          ],
          "name": ".note.gnu.build-id",
          "offset": 360,
          "segments": [
            "LOAD",
            "NOTE"
          ],
          "size": 36,
          "type": "NOTE"
        },
        {
          "alignment": 4,
          "entropy": 3.5896999504947287,
          "flags": [
            "ALLOC"
          ],
          "name": ".dynsym",
          "offset": 396,
          "segments": [
            "LOAD"
          ],
          "size": 8112,
          "type": "DYNSYM"
        },
        {
          "alignment": 1,
          "entropy": 5.066501975491169,
          "flags": [
            "ALLOC"
          ],
          "name": ".dynstr",
          "offset": 8508,
          "segments": [
            "LOAD"
          ],
          "size": 7867,
          "type": "STRTAB"
        },
        {
          "alignment": 4,
          "entropy": 2.3373712820246646,
          "flags": [
            "ALLOC"
          ],
          "name": ".hash",
          "offset": 16376,
          "segments": [
            "LOAD"
          ],
          "size": 3088,
          "type": "HASH"
        },
        {
          "alignment": 4,
          "entropy": 3.1113522297573972,
          "flags": [
            "ALLOC"
          ],
          "name": ".rel.dyn",
          "offset": 19464,
          "segments": [
            "LOAD"
          ],
          "size": 784,
          "type": "REL"
        },
        {
          "alignment": 4,
          "entropy": 4.133851502384163,
          "flags": [
            "INFO_LINK",
            "ALLOC"
          ],
          "name": ".rel.plt",
          "offset": 20248,
          "segments": [
            "LOAD"
          ],
          "size": 848,
          "type": "REL"
        },
        {
          "alignment": 4,
          "entropy": 3.7148298144277008,
          "flags": [
            "ALLOC",
            "EXECINSTR"
          ],
          "name": ".plt",
          "offset": 21096,
          "segments": [
            "LOAD"
          ],
          "size": 1292,
          "type": "PROGBITS"
        },
        {
          "alignment": 8,
          "entropy": 7.128612415708475,
          "flags": [
            "ALLOC",
            "EXECINSTR"
          ],
          "name": ".text",
          "offset": 22392,
          "size": 72128,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "ALLOC"
          ],
          "name": ".ARM.extab",
          "offset": 94520,
          "size": 780,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "LINK_ORDER",
            "ALLOC"
          ],
          "name": ".ARM.exidx",
          "offset": 95300,
          "size": 2480,
          "type": "ARM_EXIDX"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "ALLOC"
          ],
          "name": ".rodata",
          "offset": 97780,
          "size": 402932,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "WRITE",
            "ALLOC"
          ],
          "name": ".fini_array",
          "offset": 502708,
          "segments": [
            "LOAD"
          ],
          "size": 8,
          "type": "FINI_ARRAY"
        },
        {
          "alignment": 1,
          "entropy": 0,
          "flags": [
            "WRITE",
            "ALLOC"
          ],
          "name": ".init_array",
          "offset": 502716,
          "segments": [
            "LOAD"
          ],
          "size": 4,
          "type": "INIT_ARRAY"
        },
        {
          "alignment": 4,
          "entropy": 2.505028132939388,
          "flags": [
            "WRITE",
            "ALLOC"
          ],
          "name": ".dynamic",
          "offset": 84928,
          "segments": [
            "LOAD",
            "DYNAMIC"
          ],
          "size": 264,
          "type": "DYNAMIC"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "WRITE",
            "ALLOC"
          ],
          "name": ".got",
          "offset": 502984,
          "segments": [
            "LOAD"
          ],
          "size": 824,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "WRITE",
            "ALLOC"
          ],
          "name": ".data",
          "offset": 503808,
          "segments": [
            "LOAD"
          ],
          "size": 20,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 0,
          "flags": [
            "WRITE",
            "ALLOC"
          ],
          "name": ".bss",
          "offset": 503828,
          "segments": [
            "LOAD"
          ],
          "size": 3682895,
          "type": "NOBITS"
        },
        {
          "alignment": 1,
          "entropy": 0,
          "flags": [
            "MERGE",
            "STRINGS"
          ],
          "name": ".comment",
          "offset": 503828,
          "segments": [
            "LOAD"
          ],
          "size": 38,
          "type": "PROGBITS"
        },
        {
          "alignment": 4,
          "entropy": 3.6820058147602133,
          "name": ".note.gnu.gold-version",
          "offset": 22016,
          "segments": [
            "LOAD"
          ],
          "size": 28,
          "type": "NOTE"
        },
        {
          "alignment": 1,
          "entropy": 0,
          "name": ".ARM.attributes",
          "offset": 503896,
          "segments": [
            "LOAD"
          ],
          "size": 58,
          "type": "ARM_ATTRIBUTES"
        },
        {
          "alignment": 1,
          "entropy": 4.313507967746196,
          "name": ".shstrtab",
          "offset": 22016,
          "segments": [
            "LOAD"
          ],
          "size": 211,
          "type": "STRTAB"
        }
      ],
      "segments": [
        {
          "alignment": 4,
          "file_offset": 52,
          "physical": {
            "address": 52,
            "size": 288
          },
          "type": "PHDR",
          "virtual": {
            "address": 52,
            "size": 288
          }
        }
      ],
      "total": {
        "libraries": 0,
        "relocations": 0,
        "sections": 23,
        "segments": 9,
        "symbols": 0
      }
    },
    "entropy": {
      "elapsed": 0.000111,
      "entropy": 7.186938762190585
    },
    "footer": {
      "elapsed": 0.000028,
      "footer": "\u0000\u0000�\u0007\u0000\u0000�\u0007\u0000\u0000\n\u0000\u0000\u0000UPX!\r\u0017\u0003\b�Y\b\t��+U�\u0004\u0000\u0000K\u0002\u0000\u0000\u0000�\u0007\u0000\u0000\u0000\u0000^�V\u0000\u0000"
    },
    "hash": {
      "elapsed": 0.001067,
      "md5": "570e996dca15d0f3ea8ea8c3101235d5",
      "sha1": "15ca7fc3d7efa4e67a99397202da4773775c2dfa",
      "sha256": "5c88351017313468b55f8eeae0559c6e6e2b8fd3d7b37b6f6f8ad6232ef763f9",
      "ssdeep": "1536:0s7bEk2/STKcrg6uhxXcu45tXycBFkhfzmsQLlKUaMVJ:0s8/t6urZ4TtiipTa4J"
    },
    "header": {
      "elapsed": 0.00003,
      "header": "ELF\u0001\u0001\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0003\u0000(\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u00004\u0000\u0000\u0000hR\u0000\u0000\u0000\u0002\u0000\u00054\u0000 \u0000\t\u0000(\u0000\u0017\u0000"
    },
    "yara": {
      "elapsed": 0.000279,
      "matches": [
        "test"
      ]
    }
  }
}
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
