### PR TITLE
Replace interruptingcow with signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
 develop-eggs/
 dist/
 downloads/

--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -10,7 +10,6 @@ grpcio==1.42.0
 grpcio-tools==1.42.0
 html5lib==1.1
 inflection==0.5.1
-interruptingcow==0.8
 jsbeautifier==1.13.13
 libarchive-c==2.9
 lief==0.11.4

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -13,10 +13,10 @@ import os
 import re
 import string
 import sys
+import signal
 import time
 
 import inflection
-import interruptingcow
 import magic
 import redis
 import yaml
@@ -80,17 +80,18 @@ class Backend(object):
                 continue
 
             try:
-                with interruptingcow.timeout(timeout,
-                                             strelka.RequestTimeout):
-                    self.distribute(root_id, file, expire_at)
-                    p = self.coordinator.pipeline(transaction=False)
-                    p.rpush(f'event:{root_id}', 'FIN')
-                    p.expireat(f'event:{root_id}', expire_at)
-                    p.execute()
-
+                self.signal = signal.signal(signal.SIGALRM, request_timeout_handler)
+                signal.alarm(timeout)
+                self.distribute(root_id, file, expire_at)
+                p = self.coordinator.pipeline(transaction=False)
+                p.rpush(f'event:{root_id}', 'FIN')
+                p.expireat(f'event:{root_id}', expire_at)
+                p.execute()
+                signal.alarm(0)
             except strelka.RequestTimeout:
                 logging.debug(f'request {root_id} timed out')
             except Exception:
+                signal.alarm(0)
                 logging.exception('unknown exception (see traceback below)')
 
             count += 1
@@ -115,101 +116,102 @@ class Backend(object):
             files = []
 
             try:
-                with interruptingcow.timeout(self.limits.get('distribution'),
-                                             exception=strelka.DistributionTimeout):
-                    if file.depth > self.limits.get('max_depth'):
-                        logging.info(f'request {root_id} exceeded maximum depth')
-                        return
+                self.signal = signal.signal(signal.SIGALRM, distribution_timeout_handler)
+                signal.alarm(self.limits.get('distribution'))
+                if file.depth > self.limits.get('max_depth'):
+                    logging.info(f'request {root_id} exceeded maximum depth')
+                    return
 
-                    data = b''
-                    while 1:
-                        pop = self.coordinator.lpop(f'data:{file.pointer}')
-                        if pop is None:
-                            break
-                        data += pop
+                data = b''
+                while 1:
+                    pop = self.coordinator.lpop(f'data:{file.pointer}')
+                    if pop is None:
+                        break
+                    data += pop
 
-                    file.add_flavors({'mime': self.taste_mime(data)})
-                    file.add_flavors({'yara': self.taste_yara(data)})
-                    flavors = (
-                        file.flavors.get('external', [])
-                        + file.flavors.get('mime', [])
-                        + file.flavors.get('yara', [])
+                file.add_flavors({'mime': self.taste_mime(data)})
+                file.add_flavors({'yara': self.taste_yara(data)})
+                flavors = (
+                    file.flavors.get('external', [])
+                    + file.flavors.get('mime', [])
+                    + file.flavors.get('yara', [])
+                )
+
+                scanner_list = []
+                for name in self.scanners:
+                    mappings = self.scanners.get(name, {})
+                    assigned = self.assign_scanner(
+                        name,
+                        mappings,
+                        flavors,
+                        file,
                     )
+                    if assigned is not None:
+                        scanner_list.append(assigned)
+                scanner_list.sort(
+                    key=lambda k: k.get('priority', 5),
+                    reverse=True,
+                )
 
-                    scanner_list = []
-                    for name in self.scanners:
-                        mappings = self.scanners.get(name, {})
-                        assigned = self.assign_scanner(
-                            name,
-                            mappings,
-                            flavors,
+                p = self.coordinator.pipeline(transaction=False)
+                tree_dict = {
+                    'node': file.uid,
+                    'parent': file.parent,
+                    'root': root_id,
+                }
+
+                if file.depth == 0:
+                    tree_dict['node'] = root_id
+                if file.depth == 1:
+                    tree_dict['parent'] = root_id
+
+                file_dict = {
+                    'depth': file.depth,
+                    'name': file.name,
+                    'flavors': file.flavors,
+                    'scanners': [s.get('name') for s in scanner_list],
+                    'size': len(data),
+                    'source': file.source,
+                    'tree': tree_dict,
+                }
+                scan = {}
+
+                for scanner in scanner_list:
+                    try:
+                        name = scanner['name']
+                        und_name = inflection.underscore(name)
+                        scanner_import = f'strelka.scanners.{und_name}'
+                        module = importlib.import_module(scanner_import)
+                        if und_name not in self.scanner_cache:
+                            attr = getattr(module, name)(self.backend_cfg, self.coordinator)
+                            self.scanner_cache[und_name] = attr
+                        options = scanner.get('options', {})
+                        plugin = self.scanner_cache[und_name]
+                        (f, s) = plugin.scan_wrapper(
+                            data,
                             file,
+                            options,
+                            expire_at,
                         )
-                        if assigned is not None:
-                            scanner_list.append(assigned)
-                    scanner_list.sort(
-                        key=lambda k: k.get('priority', 5),
-                        reverse=True,
-                    )
+                        files.extend(f)
 
-                    p = self.coordinator.pipeline(transaction=False)
-                    tree_dict = {
-                        'node': file.uid,
-                        'parent': file.parent,
-                        'root': root_id,
-                    }
+                        scan = {
+                            **scan,
+                            **s,
+                        }
 
-                    if file.depth == 0:
-                        tree_dict['node'] = root_id
-                    if file.depth == 1:
-                        tree_dict['parent'] = root_id
+                    except ModuleNotFoundError:
+                        logging.exception(f'scanner {name} not found')
 
-                    file_dict = {
-                        'depth': file.depth,
-                        'name': file.name,
-                        'flavors': file.flavors,
-                        'scanners': [s.get('name') for s in scanner_list],
-                        'size': len(data),
-                        'source': file.source,
-                        'tree': tree_dict,
-                    }
-                    scan = {}
+                event = {
+                    **{'file': file_dict},
+                    **{'scan': scan},
+                }
 
-                    for scanner in scanner_list:
-                        try:
-                            name = scanner['name']
-                            und_name = inflection.underscore(name)
-                            scanner_import = f'strelka.scanners.{und_name}'
-                            module = importlib.import_module(scanner_import)
-                            if und_name not in self.scanner_cache:
-                                attr = getattr(module, name)(self.backend_cfg, self.coordinator)
-                                self.scanner_cache[und_name] = attr
-                            options = scanner.get('options', {})
-                            plugin = self.scanner_cache[und_name]
-                            (f, s) = plugin.scan_wrapper(
-                                data,
-                                file,
-                                options,
-                                expire_at,
-                            )
-                            files.extend(f)
-
-                            scan = {
-                                **scan,
-                                **s,
-                            }
-
-                        except ModuleNotFoundError:
-                            logging.exception(f'scanner {name} not found')
-
-                    event = {
-                        **{'file': file_dict},
-                        **{'scan': scan},
-                    }
-
-                    p.rpush(f'event:{root_id}', strelka.format_event(event))
-                    p.expireat(f'event:{root_id}', expire_at)
-                    p.execute()
+                p.rpush(f'event:{root_id}', strelka.format_event(event))
+                p.expireat(f'event:{root_id}', expire_at)
+                p.execute()
+                signal.alarm(0)
 
             except strelka.DistributionTimeout:
                 logging.exception(f'node {file.uid} timed out')
@@ -220,6 +222,7 @@ class Backend(object):
                 self.distribute(root_id, f, expire_at)
 
         except strelka.RequestTimeout:
+            signal.alarm(0)
             raise
 
     def assign_scanner(self, scanner, mappings, flavors, file):
@@ -322,6 +325,14 @@ def main():
 
     backend = Backend(backend_cfg, coordinator)
     backend.work()
+
+def request_timeout_handler(signum, frame):
+    """Signal RequestTimeout"""
+    raise strelka.RequestTimeout
+
+def distribution_timeout_handler(signum, frame):
+    """Signal DistributionTimeout"""
+    raise strelka.DistributionTimeout
 
 
 if __name__ == '__main__':

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -80,7 +80,11 @@ class Backend(object):
                 continue
 
             try:
-                self.signal = signal.signal(signal.SIGALRM, request_timeout_handler)
+                self.signal
+                self.signal = signal.signal(
+                        signal.SIGALRM,
+                        timeout_handler(strelka.RequestTimeout)
+                    )
                 signal.alarm(timeout)
                 self.distribute(root_id, file, expire_at)
                 p = self.coordinator.pipeline(transaction=False)
@@ -116,7 +120,10 @@ class Backend(object):
             files = []
 
             try:
-                self.signal = signal.signal(signal.SIGALRM, distribution_timeout_handler)
+                self.signal = signal.signal(
+                        signal.SIGALRM,
+                        timeout_handler(strelka.DistributionTimeout)
+                    )
                 signal.alarm(self.limits.get('distribution'))
                 if file.depth > self.limits.get('max_depth'):
                     logging.info(f'request {root_id} exceeded maximum depth')
@@ -326,14 +333,11 @@ def main():
     backend = Backend(backend_cfg, coordinator)
     backend.work()
 
-def request_timeout_handler(signum, frame):
-    """Signal RequestTimeout"""
-    raise strelka.RequestTimeout
-
-def distribution_timeout_handler(signum, frame):
-    """Signal DistributionTimeout"""
-    raise strelka.DistributionTimeout
-
+def timeout_handler(ex):
+    """Signal timeout handler"""
+    def fn(signum, frame):
+        raise ex
+    return fn
 
 if __name__ == '__main__':
     main()

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -148,9 +148,10 @@ class Scanner(object):
             signal.alarm(0)
         except ScannerTimeout:
             self.flags.append('timed_out')
-        except (DistributionTimeout, RequestTimeout):
-            raise
-        except Exception:
+        except Exception as e:
+            signal.alarm(0)
+            if isinstance(e, DeprecationWarning) or (e, RequestTimeout):
+                raise
             logging.exception(f'{self.name}: exception while scanning'
                               f' uid {file.uid} (see traceback below)')
             self.flags.append('uncaught_exception')


### PR DESCRIPTION
**Describe the change**

Replaces `interruptingcow` with `signal` to handle scanner timeouts using SIGALRM. The use of `interruptingcow` results in python deprecation warnings, and the library has not been updated since 2018.

This PR also removes the the `build` directory from `.gitignore`. Files in this directory should be under version control.

**Describe testing procedures**

- Add a sleep call to a Scanner configured to run longer than the Scanner's timeout - it throw an exception, and append a "timed_out" flag
- Run a scanner that completes in the allotted time - it should not raise a ScannerTimeout exception
- Explicitly throw an exception within a scanner - it should not append a "timed_out" flag. The signal should be cleared upon a non-ScannerTimeout exception

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
