### PR TITLE
Updating the link to Assemblyline

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://github.com/target/strelka/issues/188. You can bypass this compilation is
 ## Related Projects
 * [Laika BOSS](https://github.com/lmco/laikaboss)
 * [File Scanning Framework](https://github.com/EmersonElectricCo/fsf)
-* [Assemblyline](https://bitbucket.org/cse-assemblyline/)
+* [Assemblyline](https://cybercentrecanada.github.io/assemblyline4_docs/)
 
 ## Licensing
 Strelka and its associated code is released under the terms of the [Apache 2.0 License](https://github.com/phutelmyer/strelka/blob/master/LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1476,7 +1476,7 @@ Guidelines for contributing can be found [here](https://github.com/target/strelk
 ## Related Projects
 * [Laika BOSS](https://github.com/lmco/laikaboss)
 * [File Scanning Framework](https://github.com/EmersonElectricCo/fsf)
-* [Assemblyline](https://bitbucket.org/cse-assemblyline/)
+* [Assemblyline](https://cybercentrecanada.github.io/assemblyline4_docs/)
 
 ## Licensing
 Strelka and its associated code is released under the terms of the Apache 2.0 license.


### PR DESCRIPTION
**Describe the change**
The home page for the Assemblyline project has migrated from bitbucket to github. The link can be updated to reflect this change.

**Describe testing procedures**
No tests were ran but the markdown files should hopefully still render correctly.

**Sample output**
N/A.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
