### PR TITLE
Update filestream with least privilege access control

### DIFF
--- a/src/go/cmd/strelka-filestream/main.go
+++ b/src/go/cmd/strelka-filestream/main.go
@@ -115,7 +115,7 @@ func main() {
 
 	staging := conf.Staging
 	if _, err := os.Stat(staging); os.IsNotExist(err) {
-		os.Mkdir(staging, 0755)
+		os.Mkdir(staging, 0600)
 	} else {
 		match, err := filepath.Glob(filepath.Join(staging, "*"))
 		if err != nil {


### PR DESCRIPTION
**Describe the change**
Strelka filestream checks if a file staging directory exists upon execution. If a directory does not exist, filestream creates that directory with created a file staging directory  with `0755` permissions. As this directory is just used for reading / writing, additional permissions are unneeded. Reducing folder permissions to `0600` for this PR.

Noted in #213.

**Describe testing procedures**
Modified permission changes and tested filestream startup, file submission, and switches with updated permissions. No issues noted.

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
