### PR TITLE
Adding IOC Extraction

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -7,6 +7,7 @@ docker==5.0.0
 esprima==4.0.1
 eml-parser>=1.17
 git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (package installed as 'entropy')
+formulas==1.2.2
 grpcio==1.42.0
 grpcio-tools==1.42.0
 html5lib==1.1
@@ -22,6 +23,7 @@ olefile==0.46
 oletools==0.56.1
 opencv-python==4.6.0.66
 opencv-contrib-python==4.6.0.66
+openpyxl==3.0.9
 PyMuPDF==1.19.6
 pefile==2019.4.18
 pgpdump3==1.5.2
@@ -33,6 +35,7 @@ pytesseract==0.3.7
 python-docx==0.8.10
 python-magic==0.4.22
 py-tlsh==4.7.2
+pyxlsb2==0.0.8
 pyyaml>=5.4.1
 pyzbar==0.1.8
 pytz>=2022.1
@@ -43,6 +46,9 @@ rpmfile==1.0.8
 signify==0.3.0
 speakeasy-emulator==1.5.2
 ssdeep==3.4
-tldextract==3.1.0
+tldextract==3.2.0
 tnefparse==1.4.0
+validators==0.18.2
+xlrd==2.0.1
+xlrd2==1.3.4
 xmltodict==0.12.0


### PR DESCRIPTION
**Describe the change**
Adding the ability to add IOCs (IPs, FQDNs, etc) to the main strelka object.

Example (scanner):
```
    def scan(self, data, file, options, expire_at):
        results = analyzer.process_data(data=data, filename=file.name)
        if results:
            self.event['decoded'] = results.get('decoded', [])
            self.event['iocs'] = results.get('iocs', [])
            self.add_iocs(results.get('iocs', []), self.type.url, description="extracted from excel4 macro")
```

**Describe testing procedures**
Tested against scanners that utilize `self.add_iocs` function.

**Sample output**
```
      ],
      "elapsed": 0.291986,
      "iocs": [
        "http://...",
        "http://...",
        "http://...",
      ]
    },
    "yara": {
      "elapsed": 0.000172,
      "matches": [
        "test"
      ]
    },
````

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
