### PR TITLE
Adding in fix for iso extraction

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -246,7 +246,7 @@ scanners:
           - 'iso_file'
       priority: 5
       options:
-        limit: 0
+        limit: 50
   'ScanJarManifest':
     - positive:
         flavors:


### PR DESCRIPTION
**Describe the change**
A bug prevented extraction (and recursive extraction of subfiles) for different types of ISO files. This fix attempts to provide support for multiple ISO path types.

**Describe testing procedures**
Executed updated scanner against multiple types of ISO files and confirmed output works and subfiles are also extracted.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
