### PR TITLE
ScanPDF: Modification of regex throwing warning

### DIFF
--- a/src/python/strelka/scanners/scan_pdf.py
+++ b/src/python/strelka/scanners/scan_pdf.py
@@ -11,7 +11,7 @@ from strelka import strelka
 # hide PyMuPDF warnings
 fitz.TOOLS.mupdf_display_errors(False)
 phone_numbers = re.compile(
-    "\+?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?\-?\d{2,4}?",
+    "\+?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?-?\d{2,4}?",
     flags=0,
 )
 


### PR DESCRIPTION
**Describe the change**
Update phone_number regular expression in `ScanPDF` to fix warning observed during tests:


```
=============================== warnings summary ===============================
scanners/scan_pdf.py:14
  /strelka/strelka/scanners/scan_pdf.py:14: DeprecationWarning: invalid escape sequence '\+'
    "\+?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?\-?\d{2,4}?",

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 31 passed, 1 warning in 5.27s =========================
```

The updated regular expression will match phone numbers that are formatted in a variety of ways, including:

+1 (123) 456-7890
(123) 456-7890
123-456-7890
123 456 7890
123.456.7890

**Describe testing procedures**
Submitted several PDFs with phone numbers to Strelka. 

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
