### PR TITLE
ScanQR: Modification of regex throwing warning

### DIFF
--- a/src/python/strelka/scanners/scan_pdf.py
+++ b/src/python/strelka/scanners/scan_pdf.py
@@ -11,7 +11,7 @@ from strelka import strelka
 # hide PyMuPDF warnings
 fitz.TOOLS.mupdf_display_errors(False)
 phone_numbers = re.compile(
-    "\+?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?\-?\d{2,4}?",
+    r"[+]?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?\-?\d{2,4}?",
     flags=0,
 )
 

--- a/src/python/strelka/scanners/scan_pdf.py
+++ b/src/python/strelka/scanners/scan_pdf.py
@@ -11,7 +11,7 @@ from strelka import strelka
 # hide PyMuPDF warnings
 fitz.TOOLS.mupdf_display_errors(False)
 phone_numbers = re.compile(
-    r"[+]?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?\-?\d{2,4}?",
+    r"[+]?(?:\d{1,2})?\s?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{2,4}?-?\d{2,4}?",
     flags=0,
 )
 

--- a/src/python/strelka/scanners/scan_qr.py
+++ b/src/python/strelka/scanners/scan_qr.py
@@ -16,7 +16,7 @@ class ScanQr(strelka.Scanner):
     """
     def scan(self, data, file, options, expire_at):
         try:
-            URL_REGEX = r'^((https?|ftp|smtp)://)?(www.)?[a-z0-9]+\. [a-z]+(/[a-zA-Z0-9#]+/?)*'
+            URL_REGEX = r'^((https?|ftp|smtp)://)?(www\.)?[a-z0-9]+\.[a-z]+(/[a-zA-Z0-9#]+/?)*'
             barcodes = decode(Image.open(io.BytesIO(data)))
 
             try:

--- a/src/python/strelka/scanners/scan_qr.py
+++ b/src/python/strelka/scanners/scan_qr.py
@@ -16,7 +16,7 @@ class ScanQr(strelka.Scanner):
     """
     def scan(self, data, file, options, expire_at):
         try:
-            URL_REGEX = '^((https?|ftp|smtp):\/\/)?(www.)?[a-z0-9]+\.[a-z]+(\/[a-zA-Z0-9#]+\/?)*'
+            URL_REGEX = '^((https?|ftp|smtp)://)?(www.)?[a-z0-9]+\.[a-z]+(/[a-zA-Z0-9#]+/?)*'
             barcodes = decode(Image.open(io.BytesIO(data)))
 
             try:

--- a/src/python/strelka/scanners/scan_qr.py
+++ b/src/python/strelka/scanners/scan_qr.py
@@ -16,7 +16,7 @@ class ScanQr(strelka.Scanner):
     """
     def scan(self, data, file, options, expire_at):
         try:
-            URL_REGEX = '^((https?|ftp|smtp)://)?(www.)?[a-z0-9]+\.[a-z]+(/[a-zA-Z0-9#]+/?)*'
+            URL_REGEX = r'^((https?|ftp|smtp)://)?(www.)?[a-z0-9]+\. [a-z]+(/[a-zA-Z0-9#]+/?)*'
             barcodes = decode(Image.open(io.BytesIO(data)))
 
             try:


### PR DESCRIPTION
**Describe the change**
Update url regular expression in `ScanQR` to fix warning observed during tests:


```
=============================== warnings summary ===============================
/strelka/strelka/scanners/scan_qr.py:19: DeprecationWarning: invalid escape sequence '\/'
  URL_REGEX = '^((https?|ftp|smtp):\/\/)?(www.)?[a-z0-9]+\.[a-z]+(\/[a-zA-Z0-9#]+\/?)*'
```

The updated regular expression will match the same addresses as before, it's just removing extraneous escape characters.

**Describe testing procedures**
Submitted several QR documents to Strelka. 

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
