### PR TITLE
Add Cmake to dockerfile for Lief

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -qq update && \
     apt-get install --no-install-recommends -qq \
     automake \
     build-essential \
+    cmake \
     curl \
     gcc \
     git \
@@ -133,6 +134,7 @@ RUN cd /strelka/ && \
     apt-get autoremove -qq --purge \
     automake \
     build-essential \
+    cmake \
     curl \
     gcc \
     git \


### PR DESCRIPTION
**Describe the change**
Adding Cmake to Dockerfile for Python build to fix an issue with lief install.

Closes #265

**Describe testing procedures**
Running ` docker-compose -f build/docker-compose.yaml build` outputs 

```Building 1563.3s (46/46) FINISHED```


**Sample output**
n/a

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
