### PR TITLE
Added fixtures/test.xml and test_scan_xml.py

### DIFF
--- a/src/python/strelka/tests/fixtures/test.xml
+++ b/src/python/strelka/tests/fixtures/test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>flea3</name>
+  <version>0.1.0</version>
+  <description>The flea3 package</description>
+
+  <maintainer email="quchao@seas.upenn.edu">Chao Qu</maintainer>
+
+  <license>WTFPL</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>roscpp</depend>
+  <depend>nodelet</depend>
+  <depend>camera_base</depend>
+  <!--<depend>std_msgs</depend>-->
+  <depend>dynamic_reconfigure</depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
+  </export>
+</package>

--- a/src/python/strelka/tests/test_scan_xml.py
+++ b/src/python/strelka/tests/test_scan_xml.py
@@ -10,7 +10,6 @@ def test_scan_xml(mocker):
     Pass: Sample event matches output of scanner.
     Failure: Unable to load file or sample event fails to match.
     """
-
     test_scan_event = {
         "elapsed": mock.ANY,
         "namespaces": [None],
@@ -39,6 +38,6 @@ def test_scan_xml(mocker):
         scan_class=ScanUnderTest,
         fixture_path=Path(__file__).parent / "fixtures/test.xml",
     )
-    print(scanner_event)
+
     TestCase.maxDiff = None
     TestCase().assertDictEqual(test_scan_event, scanner_event)

--- a/src/python/strelka/tests/test_scan_xml.py
+++ b/src/python/strelka/tests/test_scan_xml.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from unittest import TestCase, mock
+
+from strelka.scanners.scan_xml import ScanXml as ScanUnderTest
+from strelka.tests import run_test_scan
+
+
+def test_scan_xml(mocker):
+    """
+    Pass: Sample event matches output of scanner.
+    Failure: Unable to load file or sample event fails to match.
+    """
+
+    test_scan_event = {
+        "elapsed": mock.ANY,
+        "namespaces": [None],
+        "tag_data": [],
+        "flags": [],
+        "tags": [
+            "package",
+            "name",
+            "version",
+            "description",
+            "maintainer",
+            "license",
+            "buildtool_depend",
+            "depend",
+            "build_depend",
+            "exec_depend",
+            "export",
+            "nodelet",
+        ],
+        "total": {"extracted": 0, "tags": 15},
+        "version": "1.0",
+    }
+
+    scanner_event = run_test_scan(
+        mocker=mocker,
+        scan_class=ScanUnderTest,
+        fixture_path=Path(__file__).parent / "fixtures/test.xml",
+    )
+    print(scanner_event)
+    TestCase.maxDiff = None
+    TestCase().assertDictEqual(test_scan_event, scanner_event)


### PR DESCRIPTION
**Describe the change**
Created a test for the xml scanner, 'test_scan_xml.py', with a corresponding test file, 'test.xml'.

**Describe testing procedures**
Difference test on the expected output of the xml scanner and the output of the test.xml file. 
docker-compose -f ./build/docker-compose.yaml build backend


**Sample output**
No change to Strelka's output. 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
