### PR TITLE
ScanJpeg improvements, Fix for incorrect EOI marker

### DIFF
--- a/src/python/strelka/scanners/scan_jpeg.py
+++ b/src/python/strelka/scanners/scan_jpeg.py
@@ -1,30 +1,86 @@
+import struct
+
 from strelka import strelka
 
 
 class ScanJpeg(strelka.Scanner):
-    """Extracts data embedded in JPEG files.
+    """Extracts data appended to JPEG files.
 
-    This scanner extracts data that is inserted past the JFIF trailer.
+    This scanner extracts data that is inserted past the JFIF EOI marker.
     """
+
     def scan(self, data, file, options, expire_at):
-        if not data.endswith(b'\xff\xd9'):
-            trailer_index = data.rfind(b'\xff\xd9')
-            if trailer_index == -1:
-                self.flags.append('no_trailer')
+
+        offset = 0
+
+        # Skip check for length with these markers
+        markers_zero_length = [
+            b"\xff\xd0",
+            b"\xff\xd1",
+            b"\xff\xd2",
+            b"\xff\xd3",
+            b"\xff\xd4",
+            b"\xff\xd5",
+            b"\xff\xd6",
+            b"\xff\xd7",
+            b"\xff\xd8",
+            b"\xff\x01",
+        ]
+
+        # Image must start with SOI
+        if not data[offset:].startswith(b"\xff\xd8"):
+            self.flags.append("corrupt_jpeg_data_no_soi")
+            return
+
+        # Skip SOI
+        offset += 2
+        while True:
+
+            marker = data[offset : offset + 2]
+
+            # Marker must start with 0xff
+            if marker[0] != 0xFF:
+                self.flags.append("corrupt_jpeg_data_misaligned_marker")
+                break
+
+            if marker in markers_zero_length:
+                offset += 2
+                continue
+            # Start scan data (SOS)
+            elif marker == b"\xff\xda":
+                offset += 2
+                while True:
+                    # Fast forward until we find a marker that's not FF00
+                    if data[offset] == 0xFF and data[offset + 1] != 0x00:
+                        break
+                    offset += 1
+                continue
+            # EOI marker
+            elif marker == b"\xff\xd9":
+                offset += 2
+                break
             else:
-                trailer_data = data[trailer_index + 2:]
-                if trailer_data:
-                    self.event['trailer_index'] = trailer_index
+                marker_length = struct.unpack(">H", data[offset + 2 : offset + 4])[0]
+                offset += 2
+                offset += marker_length
 
-                    extract_file = strelka.File(
-                        source=self.name,
-                    )
+        # If the end of the image is reached with no more data, return
+        if offset >= len(data):
+            self.flags.append("no_trailer")
+            return
 
-                    for c in strelka.chunk_string(trailer_data):
-                        self.upload_to_coordinator(
-                            extract_file.pointer,
-                            c,
-                            expire_at,
-                        )
+        if trailer_data := data[offset:]:
+            self.event["trailer_index"] = offset
 
-                    self.files.append(extract_file)
+            extract_file = strelka.File(
+                source=self.name,
+            )
+
+            for c in strelka.chunk_string(trailer_data):
+                self.upload_to_coordinator(
+                    extract_file.pointer,
+                    c,
+                    expire_at,
+                )
+
+            self.files.append(extract_file)

--- a/src/python/strelka/tests/test_scan_jpeg.py
+++ b/src/python/strelka/tests/test_scan_jpeg.py
@@ -11,7 +11,7 @@ def test_scan_jpeg(mocker):
     Failure: Unable to load file or sample event fails to match.
     """
 
-    test_scan_event = {"elapsed": mock.ANY, "flags": []}
+    test_scan_event = {"elapsed": mock.ANY, "flags": ["no_trailer"]}
 
     scanner_event = run_test_scan(
         mocker=mocker,
@@ -29,7 +29,7 @@ def test_scan_jpeg_pe_overlay(mocker):
     Failure: Unable to load file or sample event fails to match.
     """
 
-    test_scan_event = {"elapsed": mock.ANY, "flags": [], "trailer_index": 308564}
+    test_scan_event = {"elapsed": mock.ANY, "flags": [], "trailer_index": 308566}
 
     scanner_event = run_test_scan(
         mocker=mocker,


### PR DESCRIPTION
**Describe the change**

Updates ScanJpeg to scan for markers properly.

Fixes #270 

**Describe testing procedures**

https://www.sophos.com/en-us/medialibrary/pdfs/technical-papers/sophoslabs-uncut-mykings-report.pdf pg 27

```bash
./strelka-oneshot -f 1a606f84d7d9cb247a733db0d1f970436064da512603a207d17b7b79dd1af538 -l -
```

```json
{
  "file": {
    "depth": 1,
    "flavors": {
      "mime": [
        "application/octet-stream"
      ]
    },
    "scanners": [
      "ScanEntropy",
      "ScanFooter",
      "ScanHash",
      "ScanHeader",
      "ScanYara"
    ],
    "size": 2442004,
    "source": "ScanJpeg",
    "tree": {
      "node": "d056fdee-cc47-47a8-8148-2b002c35114d",
      "parent": "7eb4e500-908e-4725-bfda-2faf89e52a9d",
      "root": "7eb4e500-908e-4725-bfda-2faf89e52a9d"
    }
  },
  "request": {
    "attributes": {
      "filename": "1a606f84d7d9cb247a733db0d1f970436064da512603a207d17b7b79dd1af538"
    },
    "client": "go-oneshot",
    "id": "7eb4e500-908e-4725-bfda-2faf89e52a9d",
    "source": "ubuntu",
    "time": 1672389547
  },
  "scan": {
    "entropy": {
      "elapsed": 0.001532,
      "entropy": 7.941358623430145
    },
    "footer": {
      "elapsed": 2.6e-05,
      "footer": "�E�\r\u001df{�C�!,��X�r�#]�M�'\u0003Ɉ\u000eLߖ��Ў~W�Wm�j��\u001d\u0016�\u0019��"
    },
    "hash": {
      "elapsed": 0.055238,
      "md5": "e9179e391a62c87d80839bdfe4c57a7f",
      "sha1": "2a4c06f20d738c8fcbdbcde5f21024c0e5b668f2",
      "sha256": "0fad886f6cc9c9408f3942d77a45857c4a1a58c471814cdd02a6ea5ad6f0e08b",
      "ssdeep": "49152:lPOlCLnKh7LDVpNIWzN//FemhG1t+TrKfKSZXaCeQX20o8fwcZy:lPO8nKh7dpNNNnbG1zCSZXaCeQX2LCZy",
      "tlsh": "T1A4B5333FEA34A10ACE98C4BB7F6D7FCA947123D1EE19C6B98756B6903C052126D5C90C"
    },
    "header": {
      "elapsed": 4.2e-05,
      "header": "hleloina\u000bWPD.vmp.exeMZ�\u0000\u0003\u0000\u0000\u0000\u0004\u0000\u0000\u0000��\u0000\u0000�\u0000\u0000\u0000\u0000\u0000\u0000\u0000@\u0000\u0000\u0000\u0000\u0000"
    },
    "yara": {
      "elapsed": 0.003571,
      "matches": [
        "test"
      ]
    }
  }
}

```


**Sample output**



**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
