### PR TITLE
Fix Uncaught Exceptions in strelka.py

### DIFF
--- a/src/python/strelka/scanners/scan_exception.py
+++ b/src/python/strelka/scanners/scan_exception.py
@@ -1,0 +1,23 @@
+from strelka import strelka
+
+
+class ScanException(strelka.Scanner):
+    """Collects strings from files.
+
+    Collects strings from files (similar to the output of the Unix 'strings'
+    utility).
+
+    Options:
+        limit: Maximum number of strings to collect, starting from the
+            beginning of the file. If this value is 0, then all strings are
+            collected.
+            Defaults to 0 (unlimited).
+    """
+
+    def init(self):
+        pass
+
+    def scan(self, data, file, options, expire_at):
+        limit = options.get("limit", 0)
+
+        raise Exception("Scanner Exception")

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -173,12 +173,12 @@ class Scanner(object):
             signal.alarm(0)
         except ScannerTimeout:
             self.flags.append('timed_out')
+        except (DistributionTimeout, RequestTimeout):
+            raise
         except Exception as e:
             signal.alarm(0)
-            if isinstance(e, DeprecationWarning) or (e, RequestTimeout):
-                raise
             logging.exception(f'{self.name}: exception while scanning'
-                              f' uid {file.uid} (see traceback below)')
+                              f' uid {file.uid if file else "_missing_"} (see traceback below)')
             self.flags.append('uncaught_exception')
 
         self.event = {

--- a/src/python/strelka/tests/__init__.py
+++ b/src/python/strelka/tests/__init__.py
@@ -1,14 +1,9 @@
 import datetime
 from pathlib import Path
+from strelka.strelka import File
 
 
-def run_test_scan(
-    mocker,
-    scan_class,
-    fixture_path,
-    options=None,
-    backend_cfg=None
-):
+def run_test_scan(mocker, scan_class, fixture_path, options=None, backend_cfg=None):
     if options is None:
         options = {}
     if "scanner_timeout" not in options:
@@ -22,7 +17,7 @@ def run_test_scan(
 
     scanner.scan_wrapper(
         data=Path(fixture_path).read_bytes(),
-        file={"uid": "12345", "name": "test"},
+        file=File(name="test"),
         options=options,
         expire_at=datetime.date.today(),
     )

--- a/src/python/strelka/tests/test_scan_exception.py
+++ b/src/python/strelka/tests/test_scan_exception.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest import TestCase, mock
+
+from strelka.scanners.scan_exception import ScanException as ScanUnderTest
+from strelka.tests import run_test_scan
+
+
+def test_scan_exception(mocker):
+    """
+    Pass: Sample event matches output of scanner. Exception should be caught by scan_wrapper() and a flag set.
+    Failure: Unable to load file or sample event fails to match, meaning the exception was uncaught.
+    """
+
+    test_scan_event = {"elapsed": mock.ANY, "flags": ["uncaught_exception"]}
+
+    scanner_event = run_test_scan(
+        mocker=mocker,
+        scan_class=ScanUnderTest,
+        fixture_path=Path(__file__).parent / "fixtures/test.empty",
+    )
+
+    TestCase.maxDiff = None
+    TestCase().assertDictEqual(test_scan_event, scanner_event)


### PR DESCRIPTION
**Describe the change**

ScanLsb has no exception handling, and as such, its exceptions are passed up to `scan_wrapper()`. This should be caught, however that was not the observed behavior. Exceptions were being raised up to `work()` causing the request to not return.

In `src/python/strelka/strelka.py`, the following section of the exception handler was missing the `isinstance()` function, causing all exceptions not otherwise caught to be raised.

```python
            if isinstance(e, DeprecationWarning) or (e, RequestTimeout):
                raise
```

From an internal fork, the bug was fixed by restructuring the exception handler.

Fixes #263 

Adds a new test that throws an exception in a scanner and verifies an event with an `uncaught_exception` flag is created.

**Describe testing procedures**

Test with broken file now causes ScanLsb to add an `uncaught_exception` flag, and log the expected line:

```
ScanLsb: exception while scanning uid cf935d9c-1fb5-4d6f-af06-4bcf604725c0 (see traceback below)
```

```
./strelka-oneshot -f src/python/strelka/tests/fixtures/test_broken_iend.png -l -

{"file":{"depth":0,"flavors":{"mime":["image/png"],"yara":["png_file"]},"scanners":["ScanEntropy","ScanExiftool","ScanFooter","ScanHash","ScanHeader","ScanLsb","ScanNf","ScanOcr","ScanPngEof","ScanQr","ScanYara"],"size":539343,"tree":{"node":"5129d06e-9f5a-4196-bb8b-de50a87e02c0","root":"5129d06e-9f5a-4196-bb8b-de50a87e02c0"}},"request":{"attributes":{"filename":"src/python/strelka/tests/fixtures/test_broken_iend.png"},"client":"go-oneshot","id":"5129d06e-9f5a-4196-bb8b-de50a87e02c0","source":"ubuntu","time":1673145441},"scan":{"entropy":{"elapsed":0.000305,"entropy":7.9413664222815745},"exiftool":{"elapsed":0.11159,"keys":[{"key":"ImageWidth","value":1236},{"key":"ImageHeight","value":891}]},"footer":{"elapsed":0.000022,"footer":"�\u0004ѷHP�\u0018a9�eK\u0000����A33�\u001c\u0000\u0000@�\u001b��\u0006A�\u000c-IF�`\u0003�КA��'F�"},"hash":{"elapsed":0.011012,"md5":"9ed62c5250273740a66836b874b2784e","sha1":"f47e1b0ebb1856347f4ad8830dcf3ae31c76aa4a","sha256":"bf041cd21bc9ae482b92175f45005a59387a0fd0af38adab9b98edf71a9b1683","ssdeep":"12288:837ZtoNwdQCzsLhGxMO1QdbKhGtiNEqdXIHw:27ZeKdQCw9GxX15miaqMw","tlsh":"T11AB42376E3871A85F09A989F8C1C0B14ADD795201B4C0CE5F4FEB92E2DE4D45CE0A9B6"},"header":{"elapsed":0.000023,"header":"�PNG\r\n\u001a\n\u0000\u0000\u0000\rIHDR\u0000\u0000\u0004�\u0000\u0000\u0003{\u0008\u0000\u0000\u0000\u0000�Θ�\u0000\u0000\u0000\tpHYs\u0000\u0000\u000b6\u0000\u0000\u000b6\u0001"},"lsb":{"elapsed":0.018358,"flags":["uncaught_exception"]},"nf":{"elapsed":0.020253,"flags":["uncaught_exception"]},"ocr":{"elapsed":0.088606,"flags":["return_code_1"]},"png_eof":{"elapsed":0.000132,"flags":["no_iend_chunk"]},"qr":{"elapsed":0.073146,"flags":["decode error"]},"yara":{"elapsed":0.002363,"matches":["test"]}}}
```

```
docker-compose -f build/docker-compose.yaml logs backend

Attaching to strelka_backend_1
backend_1      | 2023-01-08 02:43:02 - [INFO] root [strelka-backend.main]: using backend configuration /etc/strelka/backend.yaml
backend_1      | 2023-01-08 02:43:02 - [DEBUG] root [strelka-backend.main]: verified coordinator is up
backend_1      | 2023-01-08 02:43:02 - [INFO] root [strelka-backend.work]: starting up
backend_1      | libpng error: PNG input buffer is incomplete
backend_1      | 2023-01-08 02:43:09 - [ERROR] root [strelka.scan_wrapper]: ScanLsb: exception while scanning uid cf935d9c-1fb5-4d6f-af06-4bcf604725c0 (see traceback below)
backend_1      | Traceback (most recent call last):
backend_1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/strelka.py", line 172, in scan_wrapper
backend_1      |     self.scan(data, file, options, expire_at)
backend_1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/scanners/scan_lsb.py", line 14, in scan
backend_1      |     bits = self._get_bits(image)
backend_1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/scanners/scan_lsb.py", line 30, in _get_bits
backend_1      |     h, w, t = img.shape
backend_1      | AttributeError: 'NoneType' object has no attribute 'shape'
backend_1      | libpng error: PNG input buffer is incomplete
backend_1      | 2023-01-08 02:43:09 - [ERROR] root [strelka.scan_wrapper]: ScanNf: exception while scanning uid cf935d9c-1fb5-4d6f-af06-4bcf604725c0 (see traceback below)
backend_1      | Traceback (most recent call last):
backend_1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/strelka.py", line 172, in scan_wrapper
backend_1      |     self.scan(data, file, options, expire_at)
backend_1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/scanners/scan_nf.py", line 23, in scan
backend_1      |     image = cv.cvtColor(np_image, cv.COLOR_BGR2HSV)
backend_1      | cv2.error: OpenCV(4.6.0) /io/opencv/modules/imgproc/src/color.cpp:182: error: (-215:Assertion failed) !_src.empty() in function 'cvtColor'
```

**Sample output**

No changes.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
