### PR TITLE
Clear files from cached scanners in distribute()

### DIFF
--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -233,6 +233,10 @@ class Backend(object):
                             self.scanner_cache[und_name] = attr
                         options = scanner.get('options', {})
                         plugin = self.scanner_cache[und_name]
+
+                        # Clear cached scanner of files
+                        plugin.files = []
+
                         (f, s) = plugin.scan_wrapper(
                             data,
                             file,


### PR DESCRIPTION
**Describe the change**

When pulling a scanner object from cache, `distribute()` clears the `files` property before use.

```python
      name = scanner['name']
      und_name = inflection.underscore(name)
      scanner_import = f'strelka.scanners.{und_name}'
      module = importlib.import_module(scanner_import)
      if und_name not in self.scanner_cache:
          attr = getattr(module, name)(self.backend_cfg, self.coordinator)
          self.scanner_cache[und_name] = attr
      options = scanner.get('options', {})
      plugin = self.scanner_cache[und_name]

      # Clear cached scanner of files
      plugin.files = []
```

Fixes #292

**Describe testing procedures**

```
./strelka-oneshot -l - -f src/python/strelka/tests/fixtures/test.html | wc -l
2
./strelka-oneshot -l - -f src/python/strelka/tests/fixtures/test.html | wc -l
2
./strelka-oneshot -l - -f src/python/strelka/tests/fixtures/test.html | wc -l
2
```

**Sample output**

No changes

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
