### PR TITLE
Python 3.9 is needed due to a recent commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Strelka is a real-time, container-based file scanning system used for threat hunting, threat detection, and incident response. Originally based on the design established by Lockheed Martin's [Laika BOSS](https://github.com/lmco/laikaboss) and similar projects (see: [related projects](#related-projects)), Strelka's purpose is to perform file extraction and metadata collection at enterprise scale.
 
 Strelka differs from its sibling projects in a few significant ways:
-* Core codebase is Go and Python3.6+
+* Core codebase is Go and Python3.9+
 * Server components run in containers for ease and flexibility of deployment
 * OS-native client applications for Windows, Mac, and Linux
 * Built using [libraries and formats](#architecture) that allow cross-platform, cross-language support


### PR DESCRIPTION
Commit https://github.com/target/strelka/commit/0097cacc491fb990d4337006c8827d1722838a9d uses the syntax `list[dict]` which is only supported after Python 3.9.

**Describe the change**
Update readme with correct minimum Python version.

**Describe testing procedures**
No code change included.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
