### PR TITLE
ScanIso Timezone Removal

### DIFF
--- a/src/python/strelka/scanners/scan_iso.py
+++ b/src/python/strelka/scanners/scan_iso.py
@@ -125,7 +125,7 @@ class ScanIso(strelka.Scanner):
                 minute,
                 second,
             )
-            return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+            return dt.strftime('%Y-%m-%dT%H:%M:%S')
         except strelka.ScannerTimeout:
             raise
         except Exception:
@@ -160,7 +160,7 @@ class ScanIso(strelka.Scanner):
                     iso_date.minute,
                     iso_date.second,
                 )
-                dt = dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+                dt = dt.strftime('%Y-%m-%dT%H:%M:%S')
             except strelka.ScannerTimeout:
                 raise
             except Exception:

--- a/src/python/strelka/scanners/scan_iso.py
+++ b/src/python/strelka/scanners/scan_iso.py
@@ -11,12 +11,12 @@ class ScanIso(strelka.Scanner):
     """Extracts files from ISO files."""
 
     def scan(self, data, file, options, expire_at):
-        file_limit = options.get('limit', 1000)
+        file_limit = options.get("limit", 1000)
 
-        self.event['total'] = {'files': 0, 'extracted': 0}
-        self.event['files'] = []
-        self.event['hidden_dirs'] = []
-        self.event['meta'] = {}
+        self.event["total"] = {"files": 0, "extracted": 0}
+        self.event["files"] = []
+        self.event["hidden_dirs"] = []
+        self.event["meta"] = {}
 
         try:
             # ISO must be opened as a byte stream
@@ -26,38 +26,51 @@ class ScanIso(strelka.Scanner):
 
                 # Attempt to get Meta
                 try:
-                    self.event['meta']['date_created'] = self._datetime_from_volume_date(iso.pvd.volume_creation_date)
-                    self.event['meta']['date_effective'] = self._datetime_from_volume_date(iso.pvd.volume_effective_date)
-                    self.event['meta']['date_expiration'] = self._datetime_from_volume_date(iso.pvd.volume_expiration_date)
-                    self.event['meta']['date_modification'] = self._datetime_from_volume_date(iso.pvd.volume_modification_date)
-                    self.event['meta']['volume_identifier'] = iso.pvd.volume_identifier.decode()
+                    self.event["meta"][
+                        "date_created"
+                    ] = self._datetime_from_volume_date(iso.pvd.volume_creation_date)
+                    self.event["meta"][
+                        "date_effective"
+                    ] = self._datetime_from_volume_date(iso.pvd.volume_effective_date)
+                    self.event["meta"][
+                        "date_expiration"
+                    ] = self._datetime_from_volume_date(iso.pvd.volume_expiration_date)
+                    self.event["meta"][
+                        "date_modification"
+                    ] = self._datetime_from_volume_date(
+                        iso.pvd.volume_modification_date
+                    )
+                    self.event["meta"][
+                        "volume_identifier"
+                    ] = iso.pvd.volume_identifier.decode()
                 except strelka.ScannerTimeout:
                     raise
                 except Exception:
                     pass
 
                 if iso.has_udf():
-                    pathname = 'udf_path'
+                    pathname = "udf_path"
                 elif iso.has_rock_ridge():
-                    pathname = 'rr_path'
+                    pathname = "rr_path"
                 elif iso.has_joliet():
-                    pathname = 'joliet_path'
+                    pathname = "joliet_path"
                 else:
-                    pathname = 'iso_path'
+                    pathname = "iso_path"
 
-                root_entry = iso.get_record(**{pathname: '/'})
+                root_entry = iso.get_record(**{pathname: "/"})
 
                 # Iterate through ISO file tree
                 dirs = collections.deque([root_entry])
                 while dirs:
                     dir_record = dirs.popleft()
-                    ident_to_here = iso.full_path_from_dirrecord(dir_record,
-                                                                 rockridge=pathname == 'rr_path')
+                    ident_to_here = iso.full_path_from_dirrecord(
+                        dir_record, rockridge=pathname == "rr_path"
+                    )
                     if dir_record.is_dir():
                         # Try to get hidden files, not applicable to all iso types
                         try:
                             if dir_record.file_flags == 3:
-                                self.event['hidden_dirs'].append(ident_to_here)
+                                self.event["hidden_dirs"].append(ident_to_here)
 
                         except strelka.ScannerTimeout:
                             raise
@@ -73,17 +86,26 @@ class ScanIso(strelka.Scanner):
                     else:
                         try:
                             # Collect File Metadata
-                            self.event['files'].append({'filename': ident_to_here,
-                                                        'size': iso.get_record(**{pathname: ident_to_here}).data_length,
-                                                        'date_utc': self._datetime_from_iso_date(
-                                                            iso.get_record(**{pathname: ident_to_here}).date)})
+                            self.event["files"].append(
+                                {
+                                    "filename": ident_to_here,
+                                    "size": iso.get_record(
+                                        **{pathname: ident_to_here}
+                                    ).data_length,
+                                    "date_utc": self._datetime_from_iso_date(
+                                        iso.get_record(**{pathname: ident_to_here}).date
+                                    ),
+                                }
+                            )
 
                             # Extract ISO Files (If Below Option Limit)
-                            if self.event['total']['extracted'] < file_limit:
+                            if self.event["total"]["extracted"] < file_limit:
                                 try:
-                                    self.event['total']['files'] += 1
+                                    self.event["total"]["files"] += 1
                                     file_io = io.BytesIO()
-                                    iso.get_file_from_iso_fp(file_io, **{pathname: ident_to_here})
+                                    iso.get_file_from_iso_fp(
+                                        file_io, **{pathname: ident_to_here}
+                                    )
 
                                     file_io.seek(0)
                                     extract_data = file_io.read()
@@ -91,20 +113,20 @@ class ScanIso(strelka.Scanner):
                                     # Send extracted file back to Strelka
                                     self.emit_file(extract_data, name=ident_to_here)
 
-                                    self.event['total']['extracted'] += 1
+                                    self.event["total"]["extracted"] += 1
                                 except strelka.ScannerTimeout:
                                     raise
                                 except Exception as e:
-                                    self.flags.append(f'iso_extract_error: {e}')
+                                    self.flags.append(f"iso_extract_error: {e}")
                         except strelka.ScannerTimeout:
                             raise
                         except Exception:
-                            self.flags.append('iso_read_error')
+                            self.flags.append("iso_read_error")
                 iso.close()
         except strelka.ScannerTimeout:
             raise
         except Exception:
-            self.flags.append('iso_read_error')
+            self.flags.append("iso_read_error")
 
     @staticmethod
     def _datetime_from_volume_date(volume_date):
@@ -125,7 +147,7 @@ class ScanIso(strelka.Scanner):
                 minute,
                 second,
             )
-            return dt.strftime('%Y-%m-%dT%H:%M:%S')
+            return dt.strftime("%Y-%m-%dT%H:%M:%S")
         except strelka.ScannerTimeout:
             raise
         except Exception:
@@ -160,7 +182,7 @@ class ScanIso(strelka.Scanner):
                     iso_date.minute,
                     iso_date.second,
                 )
-                dt = dt.strftime('%Y-%m-%dT%H:%M:%S')
+                dt = dt.strftime("%Y-%m-%dT%H:%M:%S")
             except strelka.ScannerTimeout:
                 raise
             except Exception:

--- a/src/python/strelka/tests/test_scan_iso.py
+++ b/src/python/strelka/tests/test_scan_iso.py
@@ -17,14 +17,14 @@ def test_scan_iso(mocker):
         "flags": [],
         "total": {"files": 1, "extracted": 1},
         "files": [
-            {"filename": "/lorem.txt", "size": 4015, "date_utc": "2022-12-11T18:44:49Z"}
+            {"filename": "/lorem.txt", "size": 4015, "date_utc": "2022-12-11T18:44:49"}
         ],
         "hidden_dirs": [],
         "meta": {
-            "date_created": "2022-12-11T18:42:00Z",
+            "date_created": "2022-12-11T18:42:00",
             "date_effective": None,
             "date_expiration": None,
-            "date_modification": "2022-12-11T18:42:00Z",
+            "date_modification": "2022-12-11T18:42:00",
             "volume_identifier": "NEW_VOLUME                      ",
         },
     }


### PR DESCRIPTION
**Describe the change**
As ISO files do not store timezone data, including a Zulu time (`Z`) in times is not completely accurate and may lead to incorrect assumptions about file times. 

- Removing Zulu reference from times from `ScanIso`
- Updating `ScanIso` tests to reflect change
- Formatting `ScanIso` with `black`

**Describe testing procedures**
Executed `pytest -s src/python/strelka/tests/test_scan_iso.py`

```
(virtualenv) desktop:strelka test$ pytest -s src/python/strelka/tests/test_scan_iso.py 
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/test/Desktop/GitHub/strelka/src/python
plugins: unordered-0.5.2, mock-3.10.0
collected 1 item                                                                                                                                                                                                                                                                             

src/python/strelka/tests/test_scan_iso.py .

===================================================================================================================================== 1 passed in 0.66s ======================================================================================================================================
```

**Sample output**
```
...
            "meta": {
                "date_created": "2022-12-11T18:42:00",
                "date_effective": None,
                "date_expiration": None,
                "date_modification": "2022-12-11T18:42:00",
                "volume_identifier": "NEW_VOLUME                      ",
            },
...
```
**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
