### PR TITLE
Check Scanners At Startup, In Config Tests

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -48,11 +48,11 @@ scanners:
           - 'application/x-bzip2'
           - 'bzip2_file'
       priority: 5
-  'ScanBITS':
-    - positive:
-        flavors:
-          - 'bits_file'
-      priority: 5
+#  'ScanBITS':
+#    - positive:
+#        flavors:
+#          - 'bits_file'
+#      priority: 5
 #  'ScanCapa':
 #    - positive:
 #        flavors:
@@ -555,11 +555,6 @@ scanners:
       priority: 5
       options:
         limit: 1000
-  'ScanRuby':
-    - positive:
-        flavors:
-          - 'text/x-ruby'
-      priority: 5
   'ScanSevenZip':
     - positive:
         flavors:

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -48,11 +48,11 @@ scanners:
           - 'application/x-bzip2'
           - 'bzip2_file'
       priority: 5
-#  'ScanBITS':
-#    - positive:
-#        flavors:
-#          - 'bits_file'
-#      priority: 5
+  'ScanBITS':
+    - positive:
+        flavors:
+          - 'bits_file'
+      priority: 5
 #  'ScanCapa':
 #    - positive:
 #        flavors:

--- a/src/python/strelka/cstructs/bits/structure.py
+++ b/src/python/strelka/cstructs/bits/structure.py
@@ -180,7 +180,6 @@ class Structure:
         return len(self.getData())
 
     def pack(self, format, data, field=None):
-
         if field:
             addressField = self.findAddressFieldFor(field)
             if (addressField is not None) and (data is None):
@@ -293,7 +292,6 @@ class Structure:
         return pack(format, data)
 
     def unpack(self, format, data, dataClassOrCode=None, field=None):
-
         if field:
             addressField = self.findAddressFieldFor(field)
             if addressField is not None:
@@ -462,7 +460,6 @@ class Structure:
         return calcsize(format)
 
     def calcUnpackSize(self, format, data, field=None):
-
         # void specifier
         if format[:1] == "_":
             return 0

--- a/src/python/strelka/scanners/common/password_cracking.py
+++ b/src/python/strelka/scanners/common/password_cracking.py
@@ -8,7 +8,6 @@ from strelka import strelka
 
 
 def convert_unit_john(jtr_number: str) -> float:
-
     if jtr_number.endswith("K"):
         return float(jtr_number[:-1]) * 1000
     elif jtr_number.endswith("M"):

--- a/src/python/strelka/scanners/scan_antiword.py
+++ b/src/python/strelka/scanners/scan_antiword.py
@@ -26,6 +26,5 @@ class ScanAntiword(strelka.Scanner):
             ).communicate()
 
             if stdout:
-
                 # Send extracted file back to Strelka
                 self.emit_file(stdout, name="text")

--- a/src/python/strelka/scanners/scan_base64_pe.py
+++ b/src/python/strelka/scanners/scan_base64_pe.py
@@ -9,7 +9,6 @@ class ScanBase64PE(strelka.Scanner):
     """Decodes base64-encoded file."""
 
     def scan(self, data, file, options, expire_at):
-
         with io.BytesIO(data) as encoded_file:
             extract_data = b""
 
@@ -20,6 +19,5 @@ class ScanBase64PE(strelka.Scanner):
                 self.flags.append("not_decodable_from_base64")
 
             if extract_data:
-
                 # Send extracted file back to Strelka
                 self.emit_file(extract_data)

--- a/src/python/strelka/scanners/scan_bits.py
+++ b/src/python/strelka/scanners/scan_bits.py
@@ -64,7 +64,6 @@ class ScanBITS(strelka.Scanner):
         if len(job_data) < 128:
             return None
         try:
-
             # Because it can be expensive to parse a JOB structure if the data is not valid,
             # do a simple check to see if the job name length is valid
             name_length = struct.unpack_from("<L", job_data, 32)[0]
@@ -295,7 +294,6 @@ class BitsJob:
                 for file in v:
                     file_dict = {}
                     for k1, v1 in file.items():
-
                         # Map the transaction attribute name, skip empty, unmapped, or invalid values
                         t_alias = self.FILE_MAP.get(k1)
                         if not t_alias:

--- a/src/python/strelka/scanners/scan_dmg.py
+++ b/src/python/strelka/scanners/scan_dmg.py
@@ -51,7 +51,6 @@ class ScanDmg(strelka.Scanner):
 
             try:
                 with tempfile.TemporaryDirectory() as tmp_extract:
-
                     try:
                         (stdout, stderr) = subprocess.Popen(
                             ["7zz", "x", tmp_data.name, f"-o{tmp_extract}"],
@@ -94,7 +93,6 @@ class ScanDmg(strelka.Scanner):
                         try:
                             relname = os.path.relpath(name, tmp_extract)
                             with open(name, "rb") as extracted_file:
-
                                 # Send extracted file back to Strelka
                                 self.emit_file(extracted_file.read(), name=relname)
 
@@ -150,7 +148,6 @@ class ScanDmg(strelka.Scanner):
             )
 
             def parse_file_modes(file_modes):
-
                 file_mode_list = []
 
                 for file_mode in file_modes:
@@ -171,7 +168,6 @@ class ScanDmg(strelka.Scanner):
 
             for output_line in output_lines:
                 if output_line:
-
                     # Properties section
                     match = regex_mode_properties.match(output_line)
                     if match:
@@ -195,7 +191,6 @@ class ScanDmg(strelka.Scanner):
 
                     # Header section
                     if not mode:
-
                         match = regex_7zip_version.match(output_line)
                         if match:
                             version = regex_7zip_version.match(output_line).group(1)
@@ -204,11 +199,9 @@ class ScanDmg(strelka.Scanner):
                             continue
 
                     elif mode == "properties":
-
                         # Collect specific properties
                         match = regex_property.match(output_line)
                         if match:
-
                             if match.group(1) == "Label":
                                 partition["label"] = match.group(2)
                             elif match.group(1) == "Path":

--- a/src/python/strelka/scanners/scan_docx.py
+++ b/src/python/strelka/scanners/scan_docx.py
@@ -19,7 +19,6 @@ class ScanDocx(strelka.Scanner):
     def scan(self, data, file, options, expire_at):
         extract_text = options.get("extract_text", False)
         with io.BytesIO(data) as docx_io:
-
             try:
                 docx_doc = docx.Document(docx_io)
                 self.event["author"] = docx_doc.core_properties.author
@@ -53,7 +52,6 @@ class ScanDocx(strelka.Scanner):
                 self.event["image_count"] = 0
 
                 for paragraph in docx_doc.paragraphs:
-
                     soup = BeautifulSoup(paragraph.paragraph_format.element.xml, "xml")
                     color_list = soup.select("color")
 
@@ -77,7 +75,6 @@ class ScanDocx(strelka.Scanner):
                     self.event["white_text_in_doc"] = True
 
                 if extract_text:
-
                     text = ""
                     for paragraph in docx_doc.paragraphs:
                         text += f"{paragraph.text}\n"

--- a/src/python/strelka/scanners/scan_email.py
+++ b/src/python/strelka/scanners/scan_email.py
@@ -14,7 +14,6 @@ class ScanEmail(strelka.Scanner):
         self.event["total"] = {"attachments": 0, "extracted": 0}
 
         try:
-
             # Open and parse email byte string
             # If fail to open, return.
             try:

--- a/src/python/strelka/scanners/scan_encrypted_doc.py
+++ b/src/python/strelka/scanners/scan_encrypted_doc.py
@@ -49,7 +49,6 @@ def crack_word(
                 return
 
         if b"0 password hashes cracked" in stdout:
-
             with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_data:
                 tmp_data.write(office2john)
                 tmp_data.flush()
@@ -117,7 +116,6 @@ class ScanEncryptedDoc(strelka.Scanner):
     """
 
     def scan(self, data, file, options, expire_at):
-
         jtr_path = options.get("jtr_path", "/jtr/")
         tmp_directory = options.get("tmp_file_directory", "/tmp/")
         password_file = options.get("password_file", "/etc/strelka/passwords.dat")
@@ -127,7 +125,6 @@ class ScanEncryptedDoc(strelka.Scanner):
         max_length = options.get("max_length", 7)
 
         with io.BytesIO(data) as doc_io:
-
             msoff_doc = msoffcrypto.OfficeFile(doc_io)
             output_doc = io.BytesIO()
             if extracted_pw := crack_word(

--- a/src/python/strelka/scanners/scan_encrypted_zip.py
+++ b/src/python/strelka/scanners/scan_encrypted_zip.py
@@ -49,7 +49,6 @@ def crack_zip(
                 return
 
         if b"0 password hashes cracked" in stdout:
-
             with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_data:
                 tmp_data.write(zip2john)
                 tmp_data.flush()
@@ -111,7 +110,6 @@ class ScanEncryptedZip(strelka.Scanner):
     """
 
     def scan(self, data, file, options, expire_at):
-
         jtr_path = options.get("jtr_path", "/jtr/")
         tmp_directory = options.get("tmp_file_directory", "/tmp/")
         file_limit = options.get("limit", 1000)
@@ -125,10 +123,8 @@ class ScanEncryptedZip(strelka.Scanner):
 
         with io.BytesIO(data) as zip_io:
             try:
-
                 is_aes = False
                 with pyzipper.ZipFile(zip_io) as zip_obj:
-
                     file_list = zip_obj.filelist  # .filelist
                     for file_list_item in file_list:
                         if not file_list_item.is_dir():
@@ -140,7 +136,6 @@ class ScanEncryptedZip(strelka.Scanner):
                 with pyzipper.AESZipFile(zip_io) if is_aes else pyzipper.ZipFile(
                     zip_io
                 ) as zip_obj:
-
                     file_list = zip_obj.filelist  # .filelist
                     for file_list_item in file_list:
                         if not file_list_item.is_dir():
@@ -175,7 +170,6 @@ class ScanEncryptedZip(strelka.Scanner):
                                 )
 
                                 if extract_data:
-
                                     # Send extracted file back to Strelka
                                     self.emit_file(
                                         extract_data, name=file_item.filename

--- a/src/python/strelka/scanners/scan_exception.py
+++ b/src/python/strelka/scanners/scan_exception.py
@@ -18,5 +18,4 @@ class ScanException(strelka.Scanner):
         pass
 
     def scan(self, data, file, options, expire_at):
-
         raise Exception("Scanner Exception")

--- a/src/python/strelka/scanners/scan_html.py
+++ b/src/python/strelka/scanners/scan_html.py
@@ -93,7 +93,7 @@ class ScanHtml(strelka.Scanner):
             scripts = soup.find_all("script")
             self.event["total"]["scripts"] = len(scripts)
             self.event.setdefault("scripts", [])
-            for (index, script) in enumerate(scripts):
+            for index, script in enumerate(scripts):
                 script_flavors = [
                     script.get("language", "").lower(),
                     script.get("type", "").lower(),

--- a/src/python/strelka/scanners/scan_jpeg.py
+++ b/src/python/strelka/scanners/scan_jpeg.py
@@ -10,7 +10,6 @@ class ScanJpeg(strelka.Scanner):
     """
 
     def scan(self, data, file, options, expire_at):
-
         offset = 0
 
         # Skip check for length with these markers
@@ -35,7 +34,6 @@ class ScanJpeg(strelka.Scanner):
         # Skip SOI
         offset += 2
         while True:
-
             marker = data[offset : offset + 2]
 
             # Marker must start with 0xff

--- a/src/python/strelka/scanners/scan_json.py
+++ b/src/python/strelka/scanners/scan_json.py
@@ -25,7 +25,7 @@ class ScanJson(strelka.Scanner):
             variable: Variable to recursively parse.
         """
         if isinstance(variable, dict):
-            for (key, value) in variable.items():
+            for key, value in variable.items():
                 if key not in self.event["keys"]:
                     self.event["keys"].append(key)
                 self._get_keys(self, value)

--- a/src/python/strelka/scanners/scan_libarchive.py
+++ b/src/python/strelka/scanners/scan_libarchive.py
@@ -26,7 +26,6 @@ class ScanLibarchive(strelka.Scanner):
                         self.event["total"]["files"] += 1
 
             with libarchive.memory_reader(data) as archive:
-
                 for entry in archive:
                     if entry.isfile:
                         if self.event["total"]["extracted"] >= file_limit:

--- a/src/python/strelka/scanners/scan_macho.py
+++ b/src/python/strelka/scanners/scan_macho.py
@@ -195,7 +195,6 @@ class ScanMacho(strelka.Scanner):
                     tmp_data.flush()
 
                     with open(tmp_data.name, "rb") as f:
-
                         # Send extracted file back to Strelka
                         self.emit_file(f.read(), name=f"binary_{r}")
 

--- a/src/python/strelka/scanners/scan_ocr.py
+++ b/src/python/strelka/scanners/scan_ocr.py
@@ -41,7 +41,6 @@ class ScanOcr(strelka.Scanner):
                         ocr_file = tess_txt.read()
 
                         if ocr_file:
-
                             if split_words:
                                 self.event["text"] = ocr_file.split()
                             else:
@@ -52,7 +51,6 @@ class ScanOcr(strelka.Scanner):
                                 )
 
                             if extract_text:
-
                                 # Send extracted file back to Strelka
                                 self.emit_file(ocr_file, name="text")
 

--- a/src/python/strelka/scanners/scan_pcap.py
+++ b/src/python/strelka/scanners/scan_pcap.py
@@ -37,7 +37,6 @@ class ScanPcap(strelka.Scanner):
             tmp_data.seek(0)
 
             with tempfile.TemporaryDirectory() as tmp_extract:
-
                 try:
                     (stdout, stderr) = subprocess.Popen(
                         [
@@ -57,14 +56,12 @@ class ScanPcap(strelka.Scanner):
                         with open(
                             os.path.join(tmp_extract, "files.log"), "r"
                         ) as json_file:
-
                             # files.log is one JSON object per line, convert to array
                             file_events = json.loads(
                                 "[" + ",".join(json_file.read().splitlines()) + "]"
                             )
 
                             for file_event in file_events:
-
                                 if self.event["total"]["extracted"] >= file_limit:
                                     self.flags.append("pcap_file_limit_error")
                                     break
@@ -96,6 +93,5 @@ class ScanPcap(strelka.Scanner):
     def upload(self, name, expire_at):
         """Send extracted file to coordinator"""
         with open(name, "rb") as extracted_file:
-
             # Send extracted file back to Strelka
             self.emit_file(extracted_file.read())

--- a/src/python/strelka/scanners/scan_pgp.py
+++ b/src/python/strelka/scanners/scan_pgp.py
@@ -42,7 +42,6 @@ class ScanPgp(strelka.Scanner):
             self.flags.append("pgpdump_error")
 
     def parse_pgpdump(self, data):
-
         pgpdump_data = None
 
         try:

--- a/src/python/strelka/scanners/scan_png_eof.py
+++ b/src/python/strelka/scanners/scan_png_eof.py
@@ -8,7 +8,6 @@ class ScanPngEof(strelka.Scanner):
     """
 
     def scan(self, data, file, options, expire_at):
-
         # PNG IEND chunk
         png_iend = b"\x00\x00\x00\x00\x49\x45\x4e\x44\xae\x42\x60\x82"
 
@@ -18,7 +17,6 @@ class ScanPngEof(strelka.Scanner):
         else:
             # Locate the first occurance of the IEND chunk, the end of PNG file
             if -1 != (trailer_index := data.find(png_iend)):
-
                 trailer_index = trailer_index + len(png_iend)
                 self.event["trailer_index"] = trailer_index
                 self.event["PNG_EOF"] = data[trailer_index:]

--- a/src/python/strelka/scanners/scan_rar.py
+++ b/src/python/strelka/scanners/scan_rar.py
@@ -119,7 +119,6 @@ class ScanRar(strelka.Scanner):
                                     self.flags.append("no_password_match_found")
 
                                 if extract_data:
-
                                     # Send extracted file back to Strelka
                                     self.emit_file(
                                         extract_data, name=f"{file_info.filename}"

--- a/src/python/strelka/scanners/scan_rpm.py
+++ b/src/python/strelka/scanners/scan_rpm.py
@@ -23,7 +23,7 @@ class ScanRpm(strelka.Scanner):
             try:
                 with rpmfile.open(tmp_data.name) as rpm_obj:
                     extract_name = ""
-                    for (key, value) in rpm_obj.headers.items():
+                    for key, value in rpm_obj.headers.items():
                         if key == "arch":
                             self.event["architecture"] = value
                         elif key == "archive_compression":

--- a/src/python/strelka/scanners/scan_rtf.py
+++ b/src/python/strelka/scanners/scan_rtf.py
@@ -27,17 +27,14 @@ class ScanRtf(strelka.Scanner):
             index = rtf.server.index(rtf_object)
 
             if rtf_object.is_package:
-
                 # Send extracted file back to Strelka
                 self.emit_file(rtf_object.olepkgdata, name=rtf_object.filename)
 
             elif rtf_object.is_ole:
-
                 # Send extracted file back to Strelka
                 self.emit_file(rtf_object.oledata, name=f"rtf_object_{index}")
 
             else:
-
                 # Send extracted file back to Strelka
                 self.emit_file(rtf_object.rawdata, name=f"rtf_object_{index}")
 

--- a/src/python/strelka/scanners/scan_seven_zip.py
+++ b/src/python/strelka/scanners/scan_seven_zip.py
@@ -154,7 +154,6 @@ class ScanSevenZip(strelka.Scanner):
 
                     relname = os.path.relpath(name, tmp_extract)
                     with open(name, "rb") as extracted_file:
-
                         # Send extracted file back to Strelka
                         self.emit_file(extracted_file.read(), name=relname)
 
@@ -175,7 +174,6 @@ class ScanSevenZip(strelka.Scanner):
             self.parse_7zip_stdout(stdout.decode("utf-8"), file_limit)
 
     def parse_7zip_password(self, output_7zip):
-
         # Method = LZMA2:14 7zAES
         regex_method = re.compile(
             r"Method = (?P<compression>[^ ]+) ?(?P<encryption>.*)"
@@ -187,7 +185,6 @@ class ScanSevenZip(strelka.Scanner):
         output_lines = output_7zip.splitlines()
 
         for output_line in output_lines:
-
             # Method property
             match = regex_method.match(output_line)
             if match and match.group("encryption"):
@@ -227,7 +224,6 @@ class ScanSevenZip(strelka.Scanner):
         )
 
         def parse_file_modes(file_modes):
-
             file_mode_list = []
 
             for file_mode in file_modes:
@@ -248,7 +244,6 @@ class ScanSevenZip(strelka.Scanner):
 
         for output_line in output_lines:
             if output_line:
-
                 # Properties section
                 match = regex_mode_properties.match(output_line)
                 if match:
@@ -272,7 +267,6 @@ class ScanSevenZip(strelka.Scanner):
 
                 # Header section
                 if not mode:
-
                     match = regex_7zip_version.match(output_line)
                     if match:
                         version = regex_7zip_version.match(output_line).group(1)

--- a/src/python/strelka/scanners/scan_tar.py
+++ b/src/python/strelka/scanners/scan_tar.py
@@ -32,7 +32,6 @@ class ScanTar(strelka.Scanner):
                             try:
                                 tar_file = tar_obj.extractfile(tar_member)
                                 if tar_file is not None:
-
                                     # Send extracted file back to Strelka
                                     self.emit_file(
                                         tar_file.read(), name=tar_member.name

--- a/src/python/strelka/scanners/scan_tnef.py
+++ b/src/python/strelka/scanners/scan_tnef.py
@@ -35,7 +35,6 @@ class ScanTnef(strelka.Scanner):
         tnef_attachments = getattr(tnef, "attachments", [])
         self.event["total"]["attachments"] = len(tnef_attachments)
         for attachment in tnef_attachments:
-
             # Send extracted file back to Strelka
             self.emit_file(attachment.data, name=attachment.name.decode())
 
@@ -43,6 +42,5 @@ class ScanTnef(strelka.Scanner):
 
         tnef_html = getattr(tnef, "htmlbody", None)
         if tnef_html:
-
             # Send extracted file back to Strelka
             self.emit_file(tnef_html, name="htmlbody")

--- a/src/python/strelka/scanners/scan_vba.py
+++ b/src/python/strelka/scanners/scan_vba.py
@@ -21,8 +21,7 @@ class ScanVba(strelka.Scanner):
             if vba.detect_vba_macros():
                 extract_macros = list(vba.extract_macros())
                 self.event["total"]["files"] = len(extract_macros)
-                for (filename, stream_path, vba_filename, vba_code) in extract_macros:
-
+                for filename, stream_path, vba_filename, vba_code in extract_macros:
                     # Send extracted file back to Strelka
                     self.emit_file(vba_code, name=f"{vba_filename}")
 
@@ -36,7 +35,7 @@ class ScanVba(strelka.Scanner):
                     self.event.setdefault("ioc", [])
                     self.event.setdefault("suspicious", [])
                     macros = vba.analyze_macros()
-                    for (macro_type, keyword, description) in macros:
+                    for macro_type, keyword, description in macros:
                         if macro_type == "AutoExec":
                             self.event["auto_exec"].append(keyword)
                         elif macro_type == "Base64 String":

--- a/src/python/strelka/scanners/scan_vhd.py
+++ b/src/python/strelka/scanners/scan_vhd.py
@@ -52,7 +52,6 @@ class ScanVhd(strelka.Scanner):
 
             try:
                 with tempfile.TemporaryDirectory() as tmp_extract:
-
                     try:
                         (stdout, stderr) = subprocess.Popen(
                             ["7zz", "x", tmp_data.name, f"-o{tmp_extract}"],
@@ -89,7 +88,6 @@ class ScanVhd(strelka.Scanner):
                         try:
                             relname = os.path.relpath(name, tmp_extract)
                             with open(name, "rb") as extracted_file:
-
                                 # Send extracted file back to Strelka
                                 self.emit_file(extracted_file.read(), name=relname)
 
@@ -147,7 +145,6 @@ class ScanVhd(strelka.Scanner):
             )
 
             def parse_file_modes(file_modes):
-
                 file_mode_list = []
 
                 for file_mode in file_modes:
@@ -168,7 +165,6 @@ class ScanVhd(strelka.Scanner):
 
             for output_line in output_lines:
                 if output_line:
-
                     # Properties section
                     match = regex_mode_properties.match(output_line)
                     if match:
@@ -192,7 +188,6 @@ class ScanVhd(strelka.Scanner):
 
                     # Header section
                     if not mode:
-
                         match = regex_7zip_version.match(output_line)
                         if match:
                             version = regex_7zip_version.match(output_line).group(1)
@@ -201,11 +196,9 @@ class ScanVhd(strelka.Scanner):
                             continue
 
                     elif mode == "properties":
-
                         # Collect specific properties
                         match = regex_property.match(output_line)
                         if match:
-
                             if match.group(1) == "Label":
                                 partition["label"] = match.group(2)
                             elif match.group(1) == "Path":
@@ -254,7 +247,6 @@ class ScanVhd(strelka.Scanner):
     def upload(self, name, expire_at):
         """Send extracted file to coordinator"""
         with open(name, "rb") as extracted_file:
-
             # Send extracted file back to Strelka
             self.emit_file(
                 extracted_file.read(), name=os.path.basename(extracted_file.name)

--- a/src/python/strelka/scanners/scan_xml.py
+++ b/src/python/strelka/scanners/scan_xml.py
@@ -75,7 +75,6 @@ class ScanXml(strelka.Scanner):
                         if tag_data not in self.event["tag_data"]:
                             self.event["tag_data"].append(tag_data)
                     elif tag in xml_args["extract_tags"]:
-
                         # Send extracted file back to Strelka
                         self.emit_file(text, name=tag)
 

--- a/src/python/strelka/scanners/scan_zip.py
+++ b/src/python/strelka/scanners/scan_zip.py
@@ -40,7 +40,6 @@ class ScanZip(strelka.Scanner):
 
         with io.BytesIO(data) as zip_io:
             try:
-
                 is_aes = False
                 with pyzipper.ZipFile(zip_io) as zip_obj:
                     filelist = zip_obj.filelist
@@ -62,7 +61,6 @@ class ScanZip(strelka.Scanner):
                     # For each file in zip, gather metadata metrics and pass back to Strelka for recursive extraction.
                     for i, name in enumerate(filelist):
                         if name.file_size > 0 and name.compress_size > 0:
-
                             compress_size_total += name.compress_size
                             file_size_total += name.file_size
 
@@ -118,7 +116,6 @@ class ScanZip(strelka.Scanner):
 
                                 # Suppress sending to coordinator in favor of ScanEncryptedZip
                                 if extract_data and "encrypted" not in self.flags:
-
                                     # Send extracted file back to Strelka
                                     self.emit_file(extract_data, name=name.filename)
 

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -170,6 +170,7 @@ class Backend(object):
         return {"mime": self.taste_mime(data), "yara": self.taste_yara(data)}
 
     def check_scanners(self):
+        """attempt to import all scanners referenced in the backend configuration"""
         logging.info("checking scanners")
         if self.scanners:
             for name in self.scanners:

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -169,6 +169,17 @@ class Backend(object):
     def match_flavors(self, data: bytes) -> dict:
         return {"mime": self.taste_mime(data), "yara": self.taste_yara(data)}
 
+    def check_scanners(self):
+        logging.info("checking scanners")
+        if self.scanners:
+            for name in self.scanners:
+                try:
+                    und_name = inflection.underscore(name)
+                    scanner_import = f"strelka.scanners.{und_name}"
+                    importlib.import_module(scanner_import)
+                except ModuleNotFoundError:
+                    raise
+
     def work(self) -> None:
         """Process tasks from Redis coordinator"""
 
@@ -177,6 +188,8 @@ class Backend(object):
         if not self.coordinator:
             logging.error("no coordinator specified")
             return
+
+        self.check_scanners()
 
         count = 0
         work_start = time.time()

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -96,7 +96,6 @@ class File(object):
             self.pointer = self.uid
 
     def dictionary(self) -> dict:
-
         return {
             "depth": self.depth,
             "flavors": self.flavors,
@@ -149,7 +148,7 @@ class Backend(object):
                 f"{yara_rules}/**/*.yar*",
                 recursive=True,
             )
-            for (i, entry) in enumerate(globbed_yara):
+            for i, entry in enumerate(globbed_yara):
                 yara_filepaths[f"namespace{i}"] = entry
             self.compiled_yara = yara.compile(filepaths=yara_filepaths)
         else:

--- a/src/python/strelka/tests/test_required_for_scanner.py
+++ b/src/python/strelka/tests/test_required_for_scanner.py
@@ -5,12 +5,11 @@ from pathlib import Path
 
 
 def test_required_for_scanner(mocker):
-
     scanner_filenames = []
 
     scanner_path = Path(__file__).parent.parent / "scanners"
 
-    for (dirpath, dirnames, filenames) in walk(scanner_path):
+    for dirpath, dirnames, filenames in walk(scanner_path):
         scanner_filenames.extend(filenames)
         break
 

--- a/src/python/strelka/tests_configuration/test_scanner_import.py
+++ b/src/python/strelka/tests_configuration/test_scanner_import.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+import redis
+import yaml
+
+from strelka import strelka
+
+
+def test_scanner_import() -> None:
+    """
+    Pass: All test fixtures match the given yara and mime matches.
+    Failure: At least one test fixture does not match the given yara and mime matches.
+    """
+
+    if os.path.exists("/etc/strelka/backend.yaml"):
+        backend_cfg_path: str = "/etc/strelka/backend.yaml"
+    else:
+        backend_cfg_path: str = Path(
+            Path(__file__).parent / "../../../../configs/python/backend/backend.yaml"
+        )
+
+    with open(backend_cfg_path, "r") as f:
+        backend_cfg = yaml.safe_load(f.read())
+
+        coordinator = redis.StrictRedis(host="127.0.0.1", port=65535, db=0)
+
+        backend = strelka.Backend(backend_cfg, coordinator)
+
+        backend.check_scanners()


### PR DESCRIPTION
**Describe the change**

`work()` in `strelka.py` now calls `check_scanners()` which attempts to import all scanners enabled in the configuration. Missing scanners will throw `ModuleNotFoundError`, but any exception will be raised, halting execution when `strelka-backend` is used.

A test `src/python/strelka/tests_configuration/test_scanner_import.py` was added that calls `check_scanners()` when CONFIG_TESTS=true is set.

ScanBITS was throwing an exception and was disabled in `backend.yaml` until [it can be fixed](https://github.com/target/strelka/issues/305).

ScanRuby was in `backend.yaml` but does not exist, and was removed.

**Describe testing procedures**
Describe the tests that you ran to verify your changes (including test configurations) and instructions so we can reproduce the tests. To assist in testing, the project maintainers may ask for file samples.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
