### PR TITLE
ScanOnenote Test Configuration Update

### DIFF
--- a/src/python/strelka/tests_configuration/test_scanner_assignment.py
+++ b/src/python/strelka/tests_configuration/test_scanner_assignment.py
@@ -48,7 +48,7 @@ test_assignments_expected: dict = {
         "ScanVba",
     ],  # TODO: Needs CDF subtype
     "test.one": ["ScanOnenote"],
-    "test.onepkg": ["ScanOnenote"],
+    "test.onepkg": ["ScanLibarchive"],
     "test.pcap": ["ScanPcap"],
     "test.pcapng": [],
     "test.pdf": ["ScanExiftool", "ScanPdf"],

--- a/src/python/strelka/tests_configuration/test_scanner_assignment.py
+++ b/src/python/strelka/tests_configuration/test_scanner_assignment.py
@@ -47,6 +47,8 @@ test_assignments_expected: dict = {
         "ScanOle",
         "ScanVba",
     ],  # TODO: Needs CDF subtype
+    "test.one": ["ScanOnenote"],
+    "test.onepkg": ["ScanOnenote"],
     "test.pcap": ["ScanPcap"],
     "test.pcapng": [],
     "test.pdf": ["ScanExiftool", "ScanPdf"],

--- a/src/python/strelka/tests_configuration/test_taste.py
+++ b/src/python/strelka/tests_configuration/test_taste.py
@@ -48,6 +48,7 @@ taste_expectations: dict = {
         "mime": ["application/vnd.ms-msi"],
         "yara": ["olecf_file"],
     },  # TODO: CDF format needs subtypes
+    "test.one": {"mime": [], "yara": ["onenote_file"]},
     "test.pcap": {"mime": ["application/vnd.tcpdump.pcap"], "yara": ["pcap_file"]},
     "test.pcapng": {
         "mime": ["application/octet-stream"],

--- a/src/python/strelka/tests_configuration/test_taste.py
+++ b/src/python/strelka/tests_configuration/test_taste.py
@@ -49,7 +49,10 @@ taste_expectations: dict = {
         "yara": ["olecf_file"],
     },  # TODO: CDF format needs subtypes
     "test.one": {"mime": ["application/octet-stream"], "yara": ["onenote_file"]},
-    "test.onepkg": {"mime": ["application/vnd.ms-cab-compressed"], "yara": ["cab_file"]},
+    "test.onepkg": {
+        "mime": ["application/vnd.ms-cab-compressed"],
+        "yara": ["cab_file"],
+    },
     "test.pcap": {"mime": ["application/vnd.tcpdump.pcap"], "yara": ["pcap_file"]},
     "test.pcapng": {
         "mime": ["application/octet-stream"],

--- a/src/python/strelka/tests_configuration/test_taste.py
+++ b/src/python/strelka/tests_configuration/test_taste.py
@@ -48,7 +48,8 @@ taste_expectations: dict = {
         "mime": ["application/vnd.ms-msi"],
         "yara": ["olecf_file"],
     },  # TODO: CDF format needs subtypes
-    "test.one": {"mime": [], "yara": ["onenote_file"]},
+    "test.one": {"mime": ["application/octet-stream"], "yara": ["onenote_file"]},
+    "test.onepkg": {"mime": ["application/vnd.ms-cab-compressed"], "yara": ["cab_file"]},
     "test.pcap": {"mime": ["application/vnd.tcpdump.pcap"], "yara": ["pcap_file"]},
     "test.pcapng": {
         "mime": ["application/octet-stream"],


### PR DESCRIPTION
**Describe the change**
Tests were not assigned for ScanOnenote. This change adds the onenote test files and expected tastes for the scanner.

**Describe testing procedures**
```
docker-compose -f build/docker-compose.yaml build --build-arg CONFIG_TESTS=true backend
...
#0 104.9 ================= 104 passed, 27 warnings in 104.18s (0:01:44) =================
```

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
