### PR TITLE
Scanner Exception Fixes

### DIFF
--- a/src/python/strelka/scanners/scan_pkcs7.py
+++ b/src/python/strelka/scanners/scan_pkcs7.py
@@ -62,4 +62,4 @@ class ScanPkcs7(strelka.Scanner):
                 f"{self.__class__.__name__} Exception: Error creating temporary file for PKCS7 file."
             )
         except Exception as e:
-            self.flags(f"{self.__class__.__name__} Exception: {str(e[:50])}")
+            self.flags(f"{self.__class__.__name__} Exception: {str(e)[:50]}")

--- a/src/python/strelka/scanners/scan_zlib.py
+++ b/src/python/strelka/scanners/scan_zlib.py
@@ -19,5 +19,5 @@ class ScanZlib(strelka.Scanner):
                 f"{self.__class__.__name__} Exception: Invalid compression or decompression data."
             )
         except Exception as e:
-            self.flags(f"{self.__class__.__name__} Exception: {str(e[:50])}")
+            self.flags(f"{self.__class__.__name__} Exception: {str(e)[:50]}")
             return

--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -638,7 +638,7 @@ class Scanner(object):
             **{"flags": self.flags},
             **self.event,
         }
-        return (self.files, {self.key: self.event})
+        return self.files, {self.key: self.event}
 
     def emit_file(
         self, data: bytes, name: str = "", flavors: Optional[list[str]] = None


### PR DESCRIPTION
**Describe the change**
Issue with exception logic for scanners with general exceptions converted to `str`. String slices were being performed on the object rather than the converted `str`.

Modifies logic to properly convert object to string, followed by a string slice.

**Describe testing procedures**
```
...
Step 10/11 : USER 1001
 ---> Running in 01498e092602
Removing intermediate container 01498e092602
 ---> 790a313a5b02
Step 11/11 : ENTRYPOINT ["strelka-frontend"]
 ---> Running in 313cff4d6615
Removing intermediate container 313cff4d6615
 ---> 4412565dc73c
Successfully built 4412565dc73c
Successfully tagged build_frontend:latest
...
```

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
