### PR TITLE
Use Strelka UI Docker Image in docker-compose.yml

### DIFF
--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
       - 14268:14268    # HTTP collector accept jaeger.thrift
 
   ui:
-    build: https://github.com/target/strelka-ui.git#main
+    image: ghcr.io/target/strelka-ui/strelka-ui:20230221
     container_name: strelka_ui_1
     environment:
       - DATABASE_HOST=strelka_postgresdb_1


### PR DESCRIPTION
**Describe the change**
In Strelka's default `docker-compose.yml` file, changing the local pull and build of the [Strelka UI project ](https://github.com/target/strelka-ui) to a prebuilt docker image to reduce build time and potential errors when compiling the Strelka UI container.

**Describe testing procedures**
Built Strelka with `--no-cache` using the Strelka UI image referenced in this PR. Loaded http://localhost:9980/, logged in with `strelka:strelka` and submitted a file successfully through the Strelka pipeline.

**Sample output**
![image](https://user-images.githubusercontent.com/27167682/220624902-5ef112c3-d3ac-4dc3-a970-b3e6eddbd8ae.png)


**Checklist**
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
