### PR TITLE
Adding Passwords File to Additional Scanners

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -1,4 +1,4 @@
-version: 2023-02-13-release
+version: 2023-02-21-release
 logging_cfg: '/etc/strelka/logging.yaml'
 limits:
   max_files: 5000

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -124,6 +124,7 @@ scanners:
         max_length: 5
         scanner_timeout: 150
         log_pws: True
+        password_file: "/etc/strelka/passwords.dat"
         # brute_force: True
   'ScanEncryptedZip':
     - positive:

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -134,6 +134,7 @@ scanners:
         max_length: 5
         scanner_timeout: 150
         log_pws: True
+        password_file: '/etc/strelka/passwords.dat'
         # brute_force: True
   'ScanEntropy':
     - positive:


### PR DESCRIPTION
**Describe the change**
Prior to this request, only the `ScanZip` scanner was enabled to use a provisioned password file (default: `passwords.dat`). As `ScanZip` does not perform any password extraction, and instead waits for `ScanEncryptedZip`, this meant that the passwords file was never used. By enabling the `password_file` for `ScanEncryptedZip`, we are now attempting to open encrypted zip files with the provided password file, prior to brute forcing (if enabled).

As the password file functionality also exists in `ScanEncryptedDoc`, that has also been enabled by default.

**Describe testing procedures**
Started a local Strelka cluster and passed several password encrypted zip files through the Web UI. Prior to this change

Prior to fix (`ScanEncryptedZip`)
![image](https://user-images.githubusercontent.com/27167682/220626299-149a34f8-f088-423e-a192-bc72a5d12c91.png)

After fix (`ScanEncryptedZip`)
![image](https://user-images.githubusercontent.com/27167682/220626055-f0be8915-7dc0-4569-bb4a-fa8c75da5aeb.png)


**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
