### PR TITLE
Update CAPA to Version 5

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 ARG YARA_VERSION=4.2.3
 ARG YARA_PYTHON_VERSION=4.2.3
-ARG CAPA_VERSION=4.0.1
+ARG CAPA_VERSION=5.0.0
 ARG EXIFTOOL_VERSION=12.52
 
 # Set up package pinning for future releases (kinetic 22.10, 7zip 22.01+dfsg-2)

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -8,7 +8,7 @@ cryptography==39.0.1
 docker==5.0.0
 eml-parser>=1.17
 esprima==4.0.1
-flare-capa==4.0.1
+flare-capa==5.0.0
 formulas==1.2.6
 git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (package installed as 'entropy')
 grpcio-tools==1.42.0
@@ -39,7 +39,7 @@ pgpdump3==1.5.2
 pre-commit==3.0.1
 py-tlsh==4.7.2
 pycdlib==1.13.0
-pyelftools==0.28
+pyelftools==0.29
 pygments==2.9.0
 pylzma==0.5.0
 pytesseract==0.3.7

--- a/src/python/strelka/tests/test_scan_capa.py
+++ b/src/python/strelka/tests/test_scan_capa.py
@@ -15,7 +15,13 @@ def test_scan_capa_dotnet(mocker):
     test_scan_event = {
         "elapsed": mock.ANY,
         "flags": [],
-        "matches": unordered(["contains PDB path", "compiled to the .NET platform", "manipulate console buffer"]),
+        "matches": unordered(
+            [
+                "contains PDB path",
+                "compiled to the .NET platform",
+                "manipulate console buffer",
+            ]
+        ),
         "mitre_ids": [],
         "mitre_techniques": [],
     }

--- a/src/python/strelka/tests/test_scan_capa.py
+++ b/src/python/strelka/tests/test_scan_capa.py
@@ -15,7 +15,7 @@ def test_scan_capa_dotnet(mocker):
     test_scan_event = {
         "elapsed": mock.ANY,
         "flags": [],
-        "matches": unordered(["contains PDB path", "compiled to the .NET platform"]),
+        "matches": unordered(["contains PDB path", "compiled to the .NET platform", "manipulate console buffer"]),
         "mitre_ids": [],
         "mitre_techniques": [],
     }
@@ -24,7 +24,7 @@ def test_scan_capa_dotnet(mocker):
         mocker=mocker,
         scan_class=ScanUnderTest,
         fixture_path=Path(__file__).parent / "fixtures/test.exe",
-        options={"scanner_timeout": 20},
+        options={"scanner_timeout": 200},
     )
 
     TestCase.maxDiff = None
@@ -49,7 +49,7 @@ def test_scan_capa_elf(mocker):
         mocker=mocker,
         scan_class=ScanUnderTest,
         fixture_path=Path(__file__).parent / "fixtures/test.elf",
-        options={"scanner_timeout": 20},
+        options={"scanner_timeout": 200},
     )
 
     TestCase.maxDiff = None
@@ -87,7 +87,7 @@ def test_scan_capa_pe_xor(mocker):
         mocker=mocker,
         scan_class=ScanUnderTest,
         fixture_path=Path(__file__).parent / "fixtures/test_xor.exe",
-        options={"scanner_timeout": 20},
+        options={"scanner_timeout": 200},
     )
 
     TestCase.maxDiff = None


### PR DESCRIPTION
**Describe the change**
This PR updates CAPA to v5.
Tests have been updated to include additional rule matches in the v5 ruleset. The CAPA tests also saw increases in the timeout time for the CAPA test as some builds seem to take quite some time for those tests.

Required an update to `requirements.txt`:
- `flare-capa`
- `pyelftools`  

**Describe testing procedures**
Built containers
```
 => [16/18] RUN echo '[+] Run build checks' &&     cd /strelka/strelka/ &&     python3 -m pytest -p no:cacheprovider -s tests/ &&     if false; then python3 -m pytest -s tests_configuration/; fi &&     echo '[+] Done'                       108.3s
 => [17/18] RUN cd /strelka/ &&     rm -rf /strelka/                                                                                                                                                                                              0.4s
 => [18/18] RUN rm -rf /etc/strelka/                                                                                                                                                                                                              0.4s
 => exporting to image                                                                                                                                                                                                                            0.1s
 => => exporting layers                                                                                                                                                                                                                           0.1s
 => => writing image sha256:c4f82266c0303592f1ceff75c9076555c39e44ed9516e00fc3be40d648daeb4c                                                                                                                                                      0.0s
 => => naming to docker.io/library/build-backend        
```

**Sample output**
No output changes.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
