### PR TITLE
Add scanner options to tracing attributes in strelka.py

### DIFF
--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -747,10 +747,22 @@ class Scanner(object):
                 "scanner_timeout", self.scanner_timeout or 10
             )
 
+            # Add attributes for tracing
             current_span.set_attribute(f"{__namespace__}.scanner.name", self.name)
             current_span.set_attribute(
                 f"{__namespace__}.scanner.timeout", self.scanner_timeout
             )
+
+            attribute_options = options.copy()
+            try:
+                attribute_options.pop("scanner_timeout")
+            except Exception:
+                pass
+
+            if attribute_options:
+                current_span.set_attribute(
+                    f"{__namespace__}.scanner.options", json.dumps(attribute_options)
+                )
 
             try:
                 signal.signal(signal.SIGALRM, self.timeout_handler)


### PR DESCRIPTION
**Describe the change**

Add scanner options to tracing attributes, prevents duplicating the timeout value

**Describe testing procedures**

Enabled tracing, observed the output to be as expected.

Backend container built successfully.


**Sample output**

![image](https://user-images.githubusercontent.com/10855297/221667088-d5053c90-3cd3-49dc-bd0e-9fb62f9e8e78.png)


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
