### PR TITLE
Swap out the ScanIso mime flavor to improve support for .img files

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -297,7 +297,7 @@ scanners:
   'ScanIso':
     - positive:
         flavors:
-          - 'iso_file'
+          - 'application/x-iso9660-image'
       priority: 5
       options:
         limit: 50


### PR DESCRIPTION
**Describe the change**

Improves Strelka for support for .img files such as those in use by Qakbot.

Changes

```
  'ScanIso':
    - positive:
        flavors:
          - 'iso_file'
```

to

```
  'ScanIso':
    - positive:
        flavors:
          - 'application/x-iso9660-image'
```

**Describe testing procedures**

Built backend container successfully, with tests passing.

Scanned Qakbot sample and Strelka successfully extracted the files.

```
strelka-oneshot -l - -f qakbot/img/24a7bf6e9ddf1d012bf184564955a075780a758e7cfb7849902b5200481a7403
{"file":{"depth":0,"flavors":{"mime":["application/zip"],"yara":["zip_file","encrypted_zip"]},"name":"qakbot/img/24a7bf6e9ddf1d012bf184564955a075780a758e7cfb7849902b5200481a7403","scanners":["ScanEncryptedZip","ScanEntropy","ScanFooter","ScanHash","ScanHeader","ScanTlsh","ScanYara","ScanZip"],"size":729978,"tree":{"node":"94ea692a-4112-48c1-bdd3-9ba7efcd67a1","root":"94ea692a-4112-48c1-bdd3-9ba7efcd67a1"}},"request":{"attributes":{"filename":"qakbot/img/24a7bf6e9ddf1d012bf184564955a075780a758e7cfb7849902b5200481a7403"},"client":"go-oneshot","id":"94ea692a-4112-48c1-bdd3-9ba7efcd67a1","source":"ubuntu","time":1677548655},"scan":{"encrypted_zip":{"cracked_password":"764","elapsed":1.560858,"flags":["cracked_by_incremental"],"total":{"extracted":1,"files":1}},"entropy":{"elapsed":0.000407,"entropy":7.999729249219777},"footer":{"backslash":"\\x01\\x00\\x18\\x00t\\x9eUq\\xbaJ\\xd9\\x01t\\x9eUq\\xbaJ\\xd9\\x01\\x12\\xc7Pq\\xbaJ\\xd9\\x01PK\\x05\\x06\\x00\\x00\\x00\\x00\\x01\\x00\\x01\\x00a\\x00\\x00\\x00\\x03#\\x0b\\x00\\x00\\x00","elapsed":0.000032,"footer":"\u0001\u0000\u0018\u0000t�Uq�J�\u0001t�Uq�J�\u0001\u0012�Pq�J�\u0001PK\u0005\u0006\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000a\u0000\u0000\u0000\u0003#\u000b\u0000\u0000\u0000"},"hash":{"elapsed":0.014678,"md5":"a67c4bc6c3c2de6d0d6657005b2bcb47","sha1":"5d8267cf7e42eb805bd2938c4eed5c1203bcaf91","sha256":"24a7bf6e9ddf1d012bf184564955a075780a758e7cfb7849902b5200481a7403","ssdeep":"12288:8GVQc82flwg4sAnnLbENfGHmD1A1bI7vu9Ng+1d7D0LM3sGZJF6x:8GVI2fV4sAnLbOsmD37WvgE5ZJFU","tlsh":"T136F42314885F1F12A90A1B383E44563E0E3F0A5D1D3D7A075E3748ADE7D87DA32A2B79"},"header":{"backslash":"PK\\x03\\x04\\x14\\x00\\x01\\x00\\x08\\x00\\xf55[Ve\\xe0JB\\xd6\"\\x0b\\x00\\x00\\xa0\\x11\\x00\\x0f\\x00\\x00\\x00simpliciter.img\\xde\\xd9\\x82A\\xb8","elapsed":0.000036,"header":"PK\u0003\u0004\u0014\u0000\u0001\u0000\u0008\u0000�5[Ve�JB�\"\u000b\u0000\u0000�\u0011\u0000\u000f\u0000\u0000\u0000simpliciter.img�قA�"},"tlsh":{"elapsed":0.005896},"yara":{"elapsed":0.002271,"matches":["test"]},"zip":{"compression_rate":36.82,"elapsed":0.000261,"files":[{"compression_rate":36.82,"compression_size":729814,"file_name":"simpliciter.img","file_size":1155072}],"flags":["encrypted"],"total":{"extracted":0,"files":1}}}}
{"file":{"depth":1,"flavors":{"mime":["application/x-iso9660-image"]},"name":"simpliciter.img","scanners":["ScanEntropy","ScanFooter","ScanHash","ScanHeader","ScanIso","ScanTlsh","ScanYara"],"size":1155072,"source":"ScanEncryptedZip","tree":{"node":"d5d867cb-d27d-4348-af67-52ca90e99587","parent":"94ea692a-4112-48c1-bdd3-9ba7efcd67a1","root":"94ea692a-4112-48c1-bdd3-9ba7efcd67a1"}},"request":{"attributes":{"filename":"qakbot/img/24a7bf6e9ddf1d012bf184564955a075780a758e7cfb7849902b5200481a7403"},"client":"go-oneshot","id":"94ea692a-4112-48c1-bdd3-9ba7efcd67a1","source":"ubuntu","time":1677548655},"scan":{"entropy":{"elapsed":0.000832,"entropy":6.921965848902698},"footer":{"backslash":"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00","elapsed":0.000036,"footer":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"},"hash":{"elapsed":0.020782,"md5":"23693d7b4009938f30bce15b1c23c5f4","sha1":"c0a12e0293a2414de94bb4b079920e8558af9f3c","sha256":"b087012cc7a352a538312351d3c22bb1098c5b64107c8dca18645320e58fd92f","ssdeep":"24576:FPk0hmOhTMa2ZYhMgvTMUku6PBuehVVLJ5tmQYK5UwIS:FPk0hm6TM5ZYJrMU56PBuehVVLJ5t1Yg","tlsh":"T11335DF64A32815A6DE63637ED806C591CA31B921431312DFB2ED4A7F7B039C8637DF29"},"header":{"backslash":"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00","elapsed":0.000053,"header":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"},"iso":{"elapsed":0.020669,"files":[{"date_utc":"2021-06-10T21:15:41","filename":"/Socialize.lnk","size":991},{"date_utc":"2021-06-26T05:04:35","filename":"/HelicineBotocudo/revolutionizes.exe","size":289792},{"date_utc":"2021-05-02T20:35:07","filename":"/ruggednessIapetus/NonrecoilingCopable.png","size":269781},{"date_utc":"2021-05-23T09:20:17","filename":"/HelicineBotocudo/cymaphytePeridinium/Agathaumas.readme","size":11285},{"date_utc":"2021-05-24T05:47:07","filename":"/HelicineBotocudo/cymaphytePeridinium/bitterhead.data","size":11171},{"date_utc":"2021-04-19T13:23:48","filename":"/ruggednessIapetus/StromateidAbelonian/BrenderAutotherapy.gcv","size":12507},{"date_utc":"2021-04-02T13:19:39","filename":"/ruggednessIapetus/StromateidAbelonian/QuaysiderChurchgoer.read","size":11435},{"date_utc":"2021-04-24T20:50:24","filename":"/ruggednessIapetus/StromateidAbelonian/Unarbitrated.cmd","size":797},{"date_utc":"2021-04-30T00:20:37","filename":"/HelicineBotocudo/cymaphytePeridinium/Electrotechnics/StanchestForeskin.wsf","size":313528},{"date_utc":"2021-06-03T00:36:51","filename":"/HelicineBotocudo/cymaphytePeridinium/Electrotechnics/hyperdicrotismPinnate.NhF","size":13732},{"date_utc":"2021-03-22T13:42:25","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/FrumpiestHundredths.jmG","size":10946},{"date_utc":"2021-03-01T05:03:53","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/PhytobiologistNonspurious.Ne","size":11332},{"date_utc":"2021-02-28T06:26:35","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/preclaimVisier/ActualisedNeuropterist.jpg","size":67578},{"date_utc":"2021-03-08T05:02:10","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/preclaimVisier/Antimedically.png","size":21344},{"date_utc":"2021-02-25T10:31:44","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/preclaimVisier/PolysomicExtratorrid.smlG","size":10743},{"date_utc":"2021-02-11T15:12:41","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/preclaimVisier/cabestro.XmI","size":10457},{"date_utc":"2021-03-08T09:56:19","filename":"/ruggednessIapetus/StromateidAbelonian/panderess/preclaimVisier/itacismHyperglycaemic.info","size":11497}],"hidden_dirs":["/HelicineBotocudo","/ruggednessIapetus","/HelicineBotocudo/cymaphytePeridinium","/ruggednessIapetus/StromateidAbelonian","/HelicineBotocudo/cymaphytePeridinium/Electrotechnics","/ruggednessIapetus/StromateidAbelonian/panderess","/ruggednessIapetus/StromateidAbelonian/panderess/preclaimVisier"],"meta":{"date_created":"2023-02-27T16:00:00","volume_identifier":"CD_ROM                          "},"total":{"extracted":17,"files":17}},"tlsh":{"elapsed":0.00812},"yara":{"elapsed":0.001642,"matches":["test"]}}}

...

```

**Sample output**

None

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
