### PR TITLE
ScanPE Rich Info Additions

### DIFF
--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -248,29 +248,31 @@ def parse_rich(pe):
     try:
         if rich_data := pe.parse_rich_header():
             rich_dict = {
-                'key': rich_data['key'].hex(),
-                'clear_data': {
-                    'data': base64.b64encode(rich_data['clear_data']),
-                    'md5': hashlib.md5(rich_data['clear_data']).hexdigest(),
+                "key": rich_data["key"].hex(),
+                "clear_data": {
+                    "data": base64.b64encode(rich_data["clear_data"]),
+                    "md5": hashlib.md5(rich_data["clear_data"]).hexdigest(),
                 },
-                'raw_data': {
-                    'data': base64.b64encode(rich_data['raw_data']),
-                    'md5': hashlib.md5(rich_data['raw_data']).hexdigest(),
+                "raw_data": {
+                    "data": base64.b64encode(rich_data["raw_data"]),
+                    "md5": hashlib.md5(rich_data["raw_data"]).hexdigest(),
                 },
             }
 
-            values = rich_data['values']
-            rich_dict.update({'info': []})
+            values = rich_data["values"]
+            rich_dict.update({"info": []})
             for i in range(0, len(values), 2):
-                rich_dict['info'].append({
-                    'toolid': values[i] >> 16,
-                    'version': values[i] & 0xffff,
-                    'count': values[i + 1]
-                })
+                rich_dict["info"].append(
+                    {
+                        "toolid": values[i] >> 16,
+                        "version": values[i] & 0xFFFF,
+                        "count": values[i + 1],
+                    }
+                )
 
             return rich_dict
     except pefile.PEFormatError:
-        logging.error('pe_format_error')
+        logging.error("pe_format_error")
         return
 
 

--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -248,20 +248,30 @@ def parse_rich(pe):
     try:
         if rich_data := pe.parse_rich_header():
             rich_dict = {
-                "key": rich_data["key"].hex(),
-                "clear_data": {
-                    "data": base64.b64encode(rich_data["clear_data"]),
-                    "md5": hashlib.md5(rich_data["clear_data"]).hexdigest(),
+                'key': rich_data['key'].hex(),
+                'clear_data': {
+                    'data': base64.b64encode(rich_data['clear_data']),
+                    'md5': hashlib.md5(rich_data['clear_data']).hexdigest(),
                 },
-                "raw_data": {
-                    "data": base64.b64encode(rich_data["raw_data"]),
-                    "md5": hashlib.md5(rich_data["raw_data"]).hexdigest(),
+                'raw_data': {
+                    'data': base64.b64encode(rich_data['raw_data']),
+                    'md5': hashlib.md5(rich_data['raw_data']).hexdigest(),
                 },
             }
 
+            values = rich_data['values']
+            rich_dict.update({'info': []})
+            for i in range(0, len(values), 2):
+                rich_dict['info'].append({
+                    'toolid': values[i] >> 16,
+                    'version': values[i] & 0xffff,
+                    'count': values[i + 1]
+                })
+
             return rich_dict
     except pefile.PEFormatError:
-        return "pe_format_error"
+        logging.error('pe_format_error')
+        return
 
 
 def parse_certificates(data):


### PR DESCRIPTION
**Describe the change**
Adding functionality to `ScanPE` in an effort to extract additional rich information such as  `tool version` and `tool ID`.  The rich information can describe the visual studio tool used to compile a PE file.

**Describe testing procedures**
```
====================== 122 passed, 20 warnings in 54.07s =======================
[+] Done
Removing intermediate container cdd6be58ab9d
 ---> 7b515d99a812
Step 28/31 : USER root
 ---> Running in 7471eeca71c5
Removing intermediate container 7471eeca71c5
 ---> 5012c9e6e217
Step 29/31 : RUN cd /strelka/ &&     rm -rf /strelka/
 ---> Running in 63a5b59561b9
Removing intermediate container 63a5b59561b9
 ---> 2e8279525a45
Step 30/31 : RUN rm -rf /etc/strelka/
 ---> Running in fe4c3632c3af
Removing intermediate container fe4c3632c3af
 ---> 3284c71ed754
Step 31/31 : USER $USERNAME
 ---> Running in 7b9fa4a41ce2
Removing intermediate container 7b9fa4a41ce2
 ---> 412f43d21890
Successfully built 412f43d21890
Successfully tagged build_backend:latest
```


**Sample output**
```
"rich": {
        "raw_data": {
          "data": "4MU60aSkVIKkpFSCpKRUgt+4WIKmpFSCy7tfgqWkVIInuFqCoKRUgsu7XoKvpFSCy7tQgqCkVIJnqwmCqaRUgqSkVYIHpFSCkoJfgqOkVIJjolKCpaRUgg==",
          "md5": "93680e43cd7576fccf02573cd0b5d273"
        },
        "key": "a4a45482",
        "info": [
          {
            "toolid": 12,
            "count": 2,
            "version": 7291
          },
          {
            "toolid": 11,
            "count": 1,
            "version": 8047
          },
          {
            "toolid": 14,
            "count": 4,
            "version": 7299
          },
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
