### PR TITLE
python-magic needs a None value to use the default mime DB

### DIFF
--- a/src/python/strelka/strelka.py
+++ b/src/python/strelka/strelka.py
@@ -150,7 +150,7 @@ class Backend(object):
         )
 
         self.compiled_magic = magic.Magic(
-            magic_file=backend_cfg.get("tasting", {}).get("mime_db", ""),
+            magic_file=backend_cfg.get("tasting", {}).get("mime_db", None),
             mime=True,
         )
 


### PR DESCRIPTION
**Describe the change**
The default value for the mime_db file must be None in order for it to use the default database file in the `/usr` tree. Defaulting to an empty string `""` causes Magic to throw an exception due to a missing file at that empty path.

This likely only affects users that need to generate the config file via yaml formatters that are unable to convert `None` to `null`.

I did not create an issue. Let me know if you'd like one created and linked to this PR.

**Describe testing procedures**
Start the backend container with the `tasting.mime_db` setting deleted from the backend config file. The container will crash. Pull the fixed image and start a new container, still with the deleted setting. The container should not crash, and should start up normally.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
