### PR TITLE
Add import for GRPC gzip compression

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"gopkg.in/yaml.v2"
 
 	grpc_health_v1 "github.com/target/strelka/src/go/api/health"


### PR DESCRIPTION
**Describe the change**
This allows, but does not require, a client to use GZIP compression when calling Strelka.

Originally implemented in https://github.com/sublime-security/strelka/pull/26

**Describe testing procedures**
```
	opts := []grpc.CallOption{grpc.WaitForReady(true), grpc.UseCompressor(grpcgzip.Name)}
	scanFile, err := sc.frontend.ScanFile(ctx, opts...)
```

I modified a client to include the `grpc.UseCompressor(grpcgzip.Name)` option and validated that `grpc: Decompressor is not installed for grpc-encoding "gzip"` is returned without this change. Everything works as normal when this change is included. I also tested without the option to ensure backwards compatibility.

**Sample output**
No changes.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
