### PR TITLE
Adds  keyword to js scanner to scan ECMA6 compliant js (#33)

### DIFF
--- a/configs/python/backend/taste/taste.yara
+++ b/configs/python/backend/taste/taste.yara
@@ -701,6 +701,7 @@ rule javascript_file {
         type = "script"
     strings:
         $var = { 76 61 72 20 } // var
+        $let = { 6C 65 74 20 } // let
         $function1 = { 66 75 6E 63 74 69 6F 6E } // function
         $function2 = { 28 66 75 6E 63 74 69 6F 6E } // (function
         $function3 = { 66 75 6E 63 74 69 6F 6E [0-1] 28 } // function[0-1](
@@ -720,6 +721,7 @@ rule javascript_file {
         $unescape = { 75 6E 65 73 63 61 70 65 28 } // unescape(
     condition:
         $var at 0 or
+        $let at 0 or
         $function1 at 0 or
         $function2 at 0 or
         $if at 0 or

--- a/src/python/strelka/config/taste.yara
+++ b/src/python/strelka/config/taste.yara
@@ -688,6 +688,7 @@ rule javascript_file {
         type = "script"
     strings:
         $var = { 76 61 72 20 } // var
+        $let = { 6C 65 74 20 } // let
         $function1 = { 66 75 6E 63 74 69 6F 6E } // function
         $function2 = { 28 66 75 6E 63 74 69 6F 6E } // (function
         $function3 = { 66 75 6E 63 74 69 6F 6E [0-1] 28 } // function[0-1](
@@ -707,6 +708,7 @@ rule javascript_file {
         $unescape = { 75 6E 65 73 63 61 70 65 28 } // unescape(
     condition:
         $var at 0 or
+        $let at 0 or
         $function1 at 0 or
         $function2 at 0 or
         $if at 0 or


### PR DESCRIPTION
**Describe the change**
Include a summary of the change (with required dependencies), any issues it fixes, and relevant motivation and context.

Originally implemented here: https://github.com/sublime-security/strelka/pull/33. No merge conflicts (although that fork does have some moved around scanner config files)

Credit to @alexk307 for the change!

**Describe testing procedures**
I tested with an extremely minimal file `test.js` with contents:
```
let foo = 'bar'
```

Without this change no yara flavor is returned, and with this change the flavor `javascript_file` is returned. 

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
