### PR TITLE
Update Dockerfile reference for Strelka-UI in docker-compose files

### DIFF
--- a/build/docker-compose-no-build.yaml
+++ b/build/docker-compose-no-build.yaml
@@ -76,7 +76,7 @@ services:
       - 14268:14268    # HTTP collector accept jaeger.thrift
 
   ui:
-    image: ghcr.io/target/strelka-ui/strelka-ui:20230221
+    image: ghcr.io/target/strelka-ui/strelka-ui:20230322
     environment:
       - DATABASE_HOST=postgresdb
       - DATABASE_NAME=strelka_ui

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
       - 14268:14268    # HTTP collector accept jaeger.thrift
 
   ui:
-    image: ghcr.io/target/strelka-ui/strelka-ui:20230221
+    image: ghcr.io/target/strelka-ui/strelka-ui:20230322
     environment:
       - DATABASE_HOST=postgresdb
       - DATABASE_NAME=strelka_ui


### PR DESCRIPTION
**Describe the change**
Updated the Dockerfile reference for `strelkaui` in the following files:
- `docker-compose.yaml`
- `docker-compose-no-build.yaml`

The image version is now hardcoded instead of using the `latest` tag as that reference doesn't seem to be functioning properly.

**Describe testing procedures**
I tested the changes by deploying the application using both the `docker-compose.yaml` and `docker-compose-no-build.yaml` files. I verified that the `strelkaui` container was running and that the application was functioning properly.

**Sample output**
N/A.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
