### PR TITLE
Implement Docker Image Publishing on New Tag Creation

### DIFF
--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -27,6 +27,9 @@ jobs:
           # Stop the script on errors
           set -e
           
+          # Enable Docker BuildKit
+          export DOCKER_BUILDKIT=1
+          
           # Set tag variables
           COMMIT_HASH=$(git rev-parse --short HEAD)
           TAG_NAME=$(git describe --tags --abbrev=0)

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -51,4 +51,4 @@ jobs:
           done
 
       - name: Logout from Docker Hub
-        uses: docker/logout-action@v1
+        run: docker logout

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -51,6 +51,7 @@ jobs:
             docker build -f "${path}/Dockerfile" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" .
             docker push "${IMAGE_NAME}:${COMMIT_HASH}"
             docker push "${IMAGE_NAME}:${TAG_NAME}"
+            docker push "${IMAGE_NAME}:latest"
           done
 
       - name: Logout from Docker Hub

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -1,8 +1,9 @@
 name: Publish Latest Images to Docker Hub
 
 on:
-  push:
-    branches: [publish-images-all]
+  create:
+    tags:
+      - '*'
 
 permissions:
   contents: read
@@ -48,8 +49,7 @@ jobs:
           # Build, tag, and push each image
           for path in "${!images[@]}"; do
             IMAGE_NAME=${images[$path]}
-            docker build -f "${path}/Dockerfile" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" -t "${IMAGE_NAME}:latest" .
-            docker push "${IMAGE_NAME}:${COMMIT_HASH}"
+            docker build -f "${path}/Dockerfile" -t "${IMAGE_NAME}:${TAG_NAME}" -t "${IMAGE_NAME}:latest" .
             docker push "${IMAGE_NAME}:${TAG_NAME}"
             docker push "${IMAGE_NAME}:latest"
           done

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -2,7 +2,7 @@ name: Publish Latest Images to Docker Hub
 
 on:
   push:
-    branches: [publish-images]
+    branches: [publish-images-all]
 
 permissions:
   contents: read
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Action Repository
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -22,19 +22,33 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Tag Images
+      - name: Build, Tag and Push Images
         run: |
-          export COMMIT_HASH=$(git rev-parse --short HEAD)
-          export TAG_NAME=$(git describe --tags --abbrev=0)
-          export IMAGE_NAME=target/strelka-fileshot
-
-          docker build -f build/go/fileshot/Dockerfile -t $IMAGE_NAME:$COMMIT_HASH -t $IMAGE_NAME:$TAG_NAME .
-
-      - name: Push Images to Docker Hub
-        run: |
-          export COMMIT_HASH=$(git rev-parse --short HEAD)
-          export TAG_NAME=$(git describe --tags --abbrev=0)
-          export IMAGE_NAME=target/strelka-fileshot
+          # Stop the script on errors
+          set -e
           
-          docker push $IMAGE_NAME:$COMMIT_HASH
-          docker push $IMAGE_NAME:$TAG_NAME
+          # Set tag variables
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          TAG_NAME=$(git describe --tags --abbrev=0)
+          
+          # Define a dictionary with paths to Dockerfiles as keys and image names as values
+          declare -A images
+          images=(
+            ["build/python/backend"]="target/strelka-backend"
+            ["build/go/frontend"]="target/strelka-frontend"
+            ["build/go/fileshot"]="target/strelka-fileshot"
+            ["build/go/filestream"]="target/strelka-filestream"
+            ["build/go/oneshot"]="target/strelka-oneshot"
+            ["build/go/manager"]="target/strelka-manager"
+          )
+          
+          # Build, tag, and push each image
+          for path in "${!images[@]}"; do
+            IMAGE_NAME=${images[$path]}
+            docker build -f "${path}/Dockerfile" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" .
+            docker push "${IMAGE_NAME}:${COMMIT_HASH}"
+            docker push "${IMAGE_NAME}:${TAG_NAME}"
+          done
+
+      - name: Logout from Docker Hub
+        uses: docker/logout-action@v1

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -48,7 +48,7 @@ jobs:
           # Build, tag, and push each image
           for path in "${!images[@]}"; do
             IMAGE_NAME=${images[$path]}
-            docker build -f "${DOCKERFILE_PATH}" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" -t "${IMAGE_NAME}:latest" .
+            docker build -f "${path}/Dockerfile" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" -t "${IMAGE_NAME}:latest" .
             docker push "${IMAGE_NAME}:${COMMIT_HASH}"
             docker push "${IMAGE_NAME}:${TAG_NAME}"
             docker push "${IMAGE_NAME}:latest"

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -48,7 +48,7 @@ jobs:
           # Build, tag, and push each image
           for path in "${!images[@]}"; do
             IMAGE_NAME=${images[$path]}
-            docker build -f "${path}/Dockerfile" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" .
+            docker build -f "${DOCKERFILE_PATH}" -t "${IMAGE_NAME}:${COMMIT_HASH}" -t "${IMAGE_NAME}:${TAG_NAME}" -t "${IMAGE_NAME}:latest" .
             docker push "${IMAGE_NAME}:${COMMIT_HASH}"
             docker push "${IMAGE_NAME}:${TAG_NAME}"
             docker push "${IMAGE_NAME}:latest"


### PR DESCRIPTION
**Describe the change**
This pull request includes changes to our GitHub Actions workflow, specifically targeting the process of building and pushing Docker images. The new workflow will trigger whenever a new tag is created in the repository.

Images are now being pushed to `https://hub.docker.com/u/target`

**Changes Include:**
- The workflow is now triggered on tag creation instead of push to the publish-images branch.
- The image build and push process has been streamlined using an associative array in Bash. This should make the script more maintainable and easier to expand if we add more components in the future.
- The Dockerfiles' paths and their respective image names have been included in the associative array. This approach simplifies the process of adding or modifying Dockerfiles and corresponding images.
- Added error handling to the script. The workflow will now stop if any command within the Build, Tag and Push Images step fails.
- The script now includes comments, making it more readable and easier to understand.

**The updated workflow:**
1. Checks out the repository.
2. Logs in to Docker Hub.
3. Builds, tags, and pushes each Docker image.
4. Logs out from Docker Hub.

**Describe testing procedures**
N/A

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
