### PR TITLE
Updating Image References to DockerHub

### DIFF
--- a/build/docker-compose-no-build.yaml
+++ b/build/docker-compose-no-build.yaml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   frontend:
-    image: ghcr.io/target/strelka/frontend:20230324
+    image: target/strelka-frontend:latest
     command: strelka-frontend
     ports:
       - 57314:57314  # must match the port in frontend.yaml
@@ -23,7 +23,7 @@ services:
       - gatekeeper
 
   backend:
-    image: ghcr.io/target/strelka/backend:20230324
+    image: target/strelka-backend:latest
     command: strelka-backend
     shm_size: 512mb  # increase as necessary, required for some scanners
     networks:
@@ -39,7 +39,7 @@ services:
     #   endpoint_mode: vip
 
   manager:
-    image: ghcr.io/target/strelka/manager:20230324
+    image: target/strelka-manager:latest
     command: strelka-manager
     restart: unless-stopped
     networks:
@@ -76,7 +76,7 @@ services:
       - 14268:14268    # HTTP collector accept jaeger.thrift
 
   ui:
-    image: ghcr.io/target/strelka-ui/strelka-ui:20230322
+    image: target/strelka-ui:latest
     environment:
       - DATABASE_HOST=postgresdb
       - DATABASE_NAME=strelka_ui

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
       - 14268:14268    # HTTP collector accept jaeger.thrift
 
   ui:
-    image: ghcr.io/target/strelka-ui/strelka-ui:20230322
+    image: target/strelka-ui:latest
     environment:
       - DATABASE_HOST=postgresdb
       - DATABASE_NAME=strelka_ui


### PR DESCRIPTION
**Describe the change**
This PR updates all Docker image references in the project to use Docker Hub as the container registry. It replaces any existing registry URLs with the default Docker Hub registry URL. This change ensures that the Docker images can be pulled from the correct location without the need for explicit registry specification.

This closes #376.

**Motivation**
The current Docker image references in the project are using ghcr.io, which requires users to authenticate to ghcr.io prior to pulling. This results in a `permissions denied` response if users are not authenticated. This simplifies the image retrieval process and removes the need to authenticate to pull public images.

**Testing Procedures**
To verify the changes, the following testing procedures were performed:

```
docker-compose -f build/docker-compose.yaml up

 ⠿ Container strelka-frontend-1     Created                                                                                                                                                            0.1s
Attaching to strelka-backend-1, strelka-coordinator-1, strelka-frontend-1, strelka-gatekeeper-1, strelka-jaeger-1, strelka-manager-1, strelka-postgresdb-1, strelka-ui-1
strelka-postgresdb-1   | postgresql 12:03:18.83 
strelka-postgresdb-1   | postgresql 12:03:18.83 Welcome to the Bitnami postgresql container
strelka-postgresdb-1   | postgresql 12:03:18.83 Subscribe to project updates by watching https://github.com/bitnami/containers
strelka-postgresdb-1   | postgresql 12:03:18.83 Submit issues and feature requests at https://github.com/bitnami/containers/issues
strelka-postgresdb-1   | postgresql 12:03:18.84 
```

**Sample Output**
N/A (No changes to Strelka's output were made in this PR)

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings