### PR TITLE
Add multi-platform Go build script for Strelka executables

### DIFF
--- a/misc/build-binaries/build-all-binaries.sh
+++ b/misc/build-binaries/build-all-binaries.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is used to build Go binaries for multiple platforms.
+# It should be run from the root of the Strelka directory. 
+# The resulting executables will be output to the root of the Strelka directory.
+#
+# Each permutation of GOOS (operating system), GOARCH (architecture), and executable name
+# is built using the Go build command.
+#
+# Before running this script, ensure that you have Go installed and that you are
+# in the root of the Strelka directory. 
+# You may have to run `chmod +x misc/build-binaries/build-all-binaries.sh` to make this script executable.
+
+# Define arrays for goos, goarch, and executable
+goos=("linux" "windows" "darwin" "darwin")
+goarch=("amd64" "amd64" "amd64" "arm64")
+executables=("strelka-fileshot" "strelka-filestream" "strelka-oneshot")
+suffixes=("-linux" ".exe" "-mac64" "-macarm")
+
+# Iterate over each permutation and build
+for i in ${!goos[@]}; do
+  for executable in ${executables[@]}; do
+    GOOS=${goos[$i]} GOARCH=${goarch[$i]} go build -ldflags="-s -w" -o ${executable}${suffixes[$i]} src/go/cmd/${executable}/main.go
+  done
+done


### PR DESCRIPTION
**Describe the change**
This change introduces a new shell script for building Go binaries for multiple platforms directly from the root of the Strelka directory. The script simplifies the build process by iterating over each permutation of GOOS (operating system), GOARCH (architecture), and executable name. This script does not introduce new dependencies.

**Describe testing procedures**
To test the script, navigate to the root of the Strelka directory, and execute the script using the command `bash build-go-binaries.sh`. The script should build each of the specified Go binaries and output them to the root directory. Please ensure that you have Go installed before running the script.

**Sample output**
Running the script does not modify Strelka's output. However, it will generate the following executable files in the root of the Strelka directory:

- strelka-fileshot-linux
- strelka-fileshot.exe
- strelka-fileshot-mac64
- strelka-fileshot-macarm
- strelka-filestream-linux
- strelka-filestream.exe
- strelka-filestream-mac64
- strelka-filestream-macarm
- strelka-oneshot-linux
- strelka-oneshot.exe
- strelka-oneshot-mac64
- strelka-oneshot-macarm

The purpose of this is either to build / test executables easily or for use in submitting to new releases.

As this is an infrequent process, this will not be added as a Github Action on new releases but will instead be executed / uploaded manually.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
