### PR TITLE
Fixed bug where tasks wouldn't process if ID was included in the request

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -85,6 +85,10 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
 		if req == nil {
 			req = in.Request
 		}
+		if req.Id != "" {
+			keyd = fmt.Sprintf("data:%v", req.Id)
+			keye = fmt.Sprintf("event:%v", req.Id)
+		}
 
 		hash.Write(in.Data)
 


### PR DESCRIPTION
**Describe the change**
When a request includes their own ID, backend container are unable to find the event and data entries in Redis. This is because the keys for both the even and data are set with a UUID generated by the frontend, but when submitting the tasks the ID will the the one provided by the request. This update will update the event and data keys before they are submitting to Redis if an ID exists in the request.

**Describe testing procedures**
Ran the sample python client included in this repo.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
