### PR TITLE
Improve OneNote File Extraction and Fix IOC Storage

### DIFF
--- a/src/python/strelka/scanners/scan_onenote.py
+++ b/src/python/strelka/scanners/scan_onenote.py
@@ -4,6 +4,7 @@ import binascii
 import re
 
 from strelka.cstructs.onenote import FileDataStoreObject
+
 from strelka import strelka
 
 # This is the binary string we're searching for in the data.

--- a/src/python/strelka/scanners/scan_onenote.py
+++ b/src/python/strelka/scanners/scan_onenote.py
@@ -1,25 +1,36 @@
-# Authors: Ryan Borre
+# Authors: Ryan Borre, Paul Hutelmyer
 
 import binascii
 import re
 
 from strelka.cstructs.onenote import FileDataStoreObject
-
 from strelka import strelka
+
+# This is the binary string we're searching for in the data.
+ONE_NOTE_MAGIC = binascii.unhexlify(b"e716e3bd65261145a4c48d4d0b7a9eac")
 
 
 class ScanOnenote(strelka.Scanner):
     """Extracts embedded files in OneNote files."""
 
     def scan(self, data, file, options, expire_at):
-        try:
-            # For every embedded file, extract payload and submit back into Strelka pipeline
-            for match in re.finditer(
-                binascii.unhexlify(b"e716e3bd65261145a4c48d4d0b7a9eac"), data
-            ):
-                obj = FileDataStoreObject.parse(data[match.span(0)[0] :])
+        self.event["total"] = {"files": 0, "extracted": 0}
 
-                # Send extracted file back to Strelka
-                self.emit_file(obj.FileData)
+        try:
+            # Searching for the magic string in the data
+            for match in re.finditer(ONE_NOTE_MAGIC, data):
+                self.event["total"]["files"] += 1
+
+                try:
+                    # Parsing the found object
+                    obj = FileDataStoreObject.parse(data[match.span(0)[0] :])
+
+                    # Sending extracted file back to Strelka for further analysis
+                    self.emit_file(obj.FileData)
+                    self.event["total"]["extracted"] += 1
+                except Exception as e:
+                    self.flags.append(
+                        f"{self.__class__.__name__} Exception: {str(e)[:50]}"
+                    )
         except Exception as e:
             self.flags.append(f"{self.__class__.__name__} Exception: {str(e)[:50]}")

--- a/src/python/strelka/tests/test_scan_onenote.py
+++ b/src/python/strelka/tests/test_scan_onenote.py
@@ -11,7 +11,11 @@ def test_scan_onenote(mocker):
     Failure: Unable to load file or sample event fails to match.
     """
 
-    test_scan_event = {"elapsed": mock.ANY, "flags": []}
+    test_scan_event = {
+        "elapsed": mock.ANY,
+        "total": {"extracted": 2, "files": 2},
+        "flags": [],
+    }
 
     scanner_event = run_test_scan(
         mocker=mocker,
@@ -29,7 +33,11 @@ def test_scan_onenotepkg(mocker):
     Failure: Unable to load file or sample event fails to match.
     """
 
-    test_scan_event = {"elapsed": mock.ANY, "flags": []}
+    test_scan_event = {
+        "elapsed": mock.ANY,
+        "total": {"extracted": 0, "files": 0},
+        "flags": [],
+    }
 
     scanner_event = run_test_scan(
         mocker=mocker,


### PR DESCRIPTION
**Summary of Change**
This PR introduces some improvements to the `ScanOnenote` class in the `strelka` module and fixes the IOC feature to properly capture and store Indicators of Compromise (IOCs) in file events.

**Changes Made**
1. Added a new constant `ONE_NOTE_MAGIC` for the binary string to search for in the data.
2. In the `ScanOnenote` class, modified the `scan` method to capture statistics on the number of files processed and extracted.
3. Fixed the collection of IOCs during the scanning process.

**Describe testing procedures**
Tested `ScanOnenote` and `AddIOC` functionality with relevant scanners and files.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
