### PR TITLE
Strelka Backend Update: Ubuntu 22.10 to 23.04

### DIFF
--- a/.github/workflows/build_fileshot_daily.yml
+++ b/.github/workflows/build_fileshot_daily.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   strelka:
     name: "build strelka fileshot daily"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-23.04
     steps:
       - uses: actions/checkout@master
       - name: Builds Strelka Fileshot

--- a/.github/workflows/build_filestream_daily.yml
+++ b/.github/workflows/build_filestream_daily.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   strelka:
     name: "build strelka filestream daily"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-23.04
     steps:
       - uses: actions/checkout@master
       - name: Builds Strelka Filestream

--- a/.github/workflows/build_oneshot_daily.yml
+++ b/.github/workflows/build_oneshot_daily.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   strelka:
     name: "build strelka onshot daily"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-23.04
     steps:
       - uses: actions/checkout@master
       - name: Builds Strelka Oneshot

--- a/.github/workflows/build_strelka_daily.yml
+++ b/.github/workflows/build_strelka_daily.yml
@@ -7,7 +7,7 @@ jobs:
     name: "Build Strelka (Nightly)"
     env:
         DOCKER_BUILDKIT: 1
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-23.04
     steps:
       - uses: actions/checkout@master
       - name: Builds Strelka

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Running a file through Strelka is simple. In this section, Strelka capabilities 
 #### Step 1: Install prerequisites
 
 ```bash
-# Ubuntu 22.04
+# Ubuntu 23.04
 sudo apt install -y wget git docker docker-compose golang jq && \
 sudo usermod -aG docker $USER && \
 newgrp docker

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
@@ -10,6 +10,7 @@ ARG USER_GID=$USER_UID
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
 
 # Create the user
 RUN groupadd --gid $USER_GID $USERNAME \
@@ -20,9 +21,9 @@ ARG YARA_PYTHON_VERSION=4.3.0
 ARG CAPA_VERSION=5.0.0
 ARG EXIFTOOL_VERSION=12.52
 
-# Set up package pinning for future releases (kinetic 22.10, 7zip 22.01+dfsg-2)
+# Set up package pinning for future releases (mantic 23.04, 7zip 23.01+dfsg-2)
 COPY ./build/python/backend/pin.pref /etc/apt/preferences.d/pin.pref
-COPY ./build/python/backend/kinetic.list /etc/apt/sources.list.d/kinetic.list
+COPY ./build/python/backend/lunar.list /etc/apt/sources.list.d/lunar.list
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
@@ -49,8 +50,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pkg-config
 
 # Add zeek repo
-RUN echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_22.04/ /' | tee /etc/apt/sources.list.d/security:zeek.list && \
-    curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_22.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+RUN echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_23.04/ /' | tee /etc/apt/sources.list.d/security:zeek.list && \
+    curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_23.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/build/python/backend/kinetic.list
+++ b/build/python/backend/kinetic.list
@@ -1,2 +1,0 @@
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu kinetic main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ kinetic main restricted universe multiverse

--- a/build/python/backend/lunar.list
+++ b/build/python/backend/lunar.list
@@ -1,0 +1,2 @@
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu lunar main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ lunar main restricted universe multiverse

--- a/build/python/backend/pin.pref
+++ b/build/python/backend/pin.pref
@@ -3,5 +3,5 @@ Pin: release n=jammy
 Pin-Priority: 100
 
 Package: *
-Pin: release n=kinetic
+Pin: release n=lunar
 Pin-Priority: 200

--- a/docs/README.md
+++ b/docs/README.md
@@ -209,7 +209,7 @@ By default, Strelka is configured to use a minimal "quickstart" deployment that 
 #### Step 1: Install prerequisites
 
 ```bash
-# Ubuntu 22.04
+# Ubuntu 23.04
 sudo apt install -y wget git docker docker-compose golang jq && \
 sudo usermod -aG docker $USER && \
 newgrp docker


### PR DESCRIPTION
**Describe the change**
This PR updates the Strelka backend to support Ubuntu 23.04, includes changes to the README, and updates workflows. Additionally, it introduces `ENV PIP_BREAK_SYSTEM_PACKAGES 1` in the `backend` Dockerfile to address the changes introduced in [PEP 668](https://peps.python.org/pep-0668/).

- Updated the backend to use Ubuntu 23.04.
- Updated relevant documentation in the README.
- Adjusted GitHub workflows to ensure compatibility.
- Added `ENV PIP_BREAK_SYSTEM_PACKAGES 1` in the Dockerfile.

**Describe testing procedures**
All tests passed successfully, tested submission of various files manually through the UI.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
