### PR TITLE
Safely Account for a YARA Compilation Failure

### DIFF
--- a/src/python/strelka/tests/fixtures/test_elk_linux_torte.yara
+++ b/src/python/strelka/tests/fixtures/test_elk_linux_torte.yara
@@ -1,0 +1,48 @@
+/*
+    This Yara ruleset is under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html) and open to any user or organization, as
+    long as you use it under this license.
+*/
+
+rule ELF_Linux_Torte : Linux ELF
+
+{
+    meta:
+		author = "@mmorenog,@yararules"
+		description = "Detects ELF Linux/Torte infection"
+		ref = "http://blog.malwaremustdie.org/2016/01/mmd-0050-2016-incident-report-elf.html"
+		hash1 = "1faf27f6b8e8a9cadb611f668a01cf73"
+		hash2 = "cb0477445fef9c5f1a5b6689bbfb941e"
+
+    strings:
+        $s0 = "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7.6)"
+        $s1 = "Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.7.6)"
+        $s2 = "?sessd="
+        $s3 = "&sessc="
+        $s4 = "&sessk="
+        $s5 = "3a08fe7b8c4da6ed09f21c3ef97efce2"
+        $s6 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        $s7 = "_ZN11CThreadPool10getBatchesERSt6vectorISt4pairISsiESaIS2_EE"
+        $s8 = "_ZNSs4_Rep10_M_destroyERKSaIcE@@GLIBCXX_3.4"
+        $s9 = "_ZNSt6vectorImSaImEE13_M_insert_auxEN9__gnu_cxx17__normal_iteratorIPmS1_EERKm"
+        $s10 = "_ZNSt6vectorISt4pairISsiESaIS1_EE13_M_insert_auxEN9__gnu_cxx17__normal_iteratorIPS1_S3_EERKS1_"
+        $s11 = "_ZSt20__throw_out_of_rangePKc@@GLIBCXX_3.4"
+
+        condition:
+        is__elf and all of ($s*)
+}
+
+
+rule ELF_Linux_Torte_domains {
+	meta:
+		author = "@mmorenog,@yararules"
+		description = "Detects ELF Linux/Torte infection"
+		ref1 = "http://blog.malwaremustdie.org/2016/01/mmd-0050-2016-incident-report-elf.html"
+	strings:
+		$1 = "pages.touchpadz.com" ascii wide nocase
+		$2 = "bat.touchpadz.com" ascii wide nocase
+		$3 = "stat.touchpadz.com" ascii wide nocase
+		$4 = "sk2.touchpadz.com" ascii wide nocase
+
+	condition:
+		any of them
+}

--- a/src/python/strelka/tests/test_scan_yara.py
+++ b/src/python/strelka/tests/test_scan_yara.py
@@ -73,7 +73,6 @@ def test_scan_bad_yara(mocker):
         },
     )
 
-    print(scanner_event)  # Add this line to check the actual value of "rules_loaded"
     TestCase.maxDiff = None
     TestCase().assertDictEqual(test_scan_event, scanner_event)
 

--- a/src/python/strelka/tests/test_scan_yara.py
+++ b/src/python/strelka/tests/test_scan_yara.py
@@ -38,6 +38,46 @@ def test_scan_yara(mocker):
     TestCase().assertDictEqual(test_scan_event, scanner_event)
 
 
+def test_scan_bad_yara(mocker):
+    """
+    This test was implemented to test a more complex and unsupported rule. A bug was observed that was
+    not triggered by the basic YARA test.
+    Src: https://github.com/target/strelka/issues/410
+    Pass: Sample event matches output of scanner.
+    Failure: Unable to load file or sample event fails to match.
+    """
+
+    test_scan_event = {
+        "elapsed": mock.ANY,
+        "flags": [
+            'compiling_error_general_/strelka/strelka/tests/fixtures/test_elk_linux_torte.yara(31): undefined identifier "is__elf"',
+            "no_rules_loaded",
+        ],
+        "matches": [],
+        "rules_loaded": 0,
+        "meta": mock.ANY,
+        "tags": [],
+        "hex": [],
+    }
+
+    scanner_event = run_test_scan(
+        mocker=mocker,
+        scan_class=ScanUnderTest,
+        fixture_path=Path(__file__).parent / "fixtures/test.txt",
+        options={
+            "location": str(Path(Path(__file__).parent / "fixtures/")),
+            "compiled": {
+                "enabled": False,
+                "filename": "rules.compiled",
+            },
+        },
+    )
+
+    print(scanner_event)  # Add this line to check the actual value of "rules_loaded"
+    TestCase.maxDiff = None
+    TestCase().assertDictEqual(test_scan_event, scanner_event)
+
+
 def test_scan_yara_hex_extraction(mocker):
     """
     Pass: Sample event matches output of scanner.


### PR DESCRIPTION
**Describe the change**
As identified in #410, Strelka will fail to load YARA, and subsequently fail to scan, if an unsupported YARA rule is ingested. This can be fixed by curating YARA rules prior to use in Strelka, however, to account for safe loading, we are now checking for a properly loaded compiled YARA prior to use. 

Note: This _may_ still fail if users remove the default test YARA and push unsupported YARA rules.
 
**Describe testing procedures**
A [test](https://github.com/target/strelka/compare/yara-compiled-fix?expand=1#diff-6b04f0ac7aa000b5deffb1642e618f703394aa3d4d465790feb836096334679e) using an [unsupported YARA rule](https://github.com/target/strelka/compare/yara-compiled-fix?expand=1#diff-a66a7924ff4e1bc923d547b6347cedfbf96f2767011847261e42c9923b5f89ca) was created. This test successfully passes, which prior to the changes, did not. Strelka should not fail anymore using the default patterns + any unsupported patterns.

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
