### PR TITLE
ScanYara Safe Key Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,15 @@ Guidelines for contributing can be found [here](https://github.com/target/strelk
 
 ## Known Issues
 
-See [issues labeled `bug`](https://github.com/target/strelka/issues?q=is%3Aissue+is%3Aopen+label%3Abug) in the tracker for any potential known issues.
+
+### Issues with Loading YARA Rules
+Users are advised to precompile their YARA rules for optimal performance and to avoid potential issues during runtime. 
+Using precompiled YARA files helps in reducing load time and resource usage, especially in environments with a large 
+set of rules. Ensure to use the [compiled option in the Strelka configuration](https://github.com/target/strelka/blob/master/configs/python/backend/backend.yaml) 
+to point to the precompiled rules file. 
+
+### Other Issues
+See [issues labeled `bug`](https://github.com/target/strelka/issues?q=is%3Aissue+is%3Aopen+label%3Abug) in the tracker for any additional issues.
 
 ## Related Projects
 * [Laika BOSS](https://github.com/lmco/laikaboss)

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -75,11 +75,11 @@ services:
     networks:
       - net
     ports:
-      - 16686:16686    # HTTP query     frontend UI
-      - 6831:6831/udp  # UDP  agent     accept jaeger.thrift over Thrift-compact protocol (used by most SDKs)
-      - 4317:4317      # HTTP collector accept OpenTelemetry Protocol (OTLP) over gRPC
-      - 4318:4318      # HTTP collector accept OpenTelemetry Protocol (OTLP) over HTTP
-      - 14268:14268    # HTTP collector accept jaeger.thrift
+      - "16686:16686"    # HTTP query     frontend UI
+      - "6831:6831/udp"  # UDP  agent     accept jaeger.thrift over Thrift-compact protocol (used by most SDKs)
+      - "4317:4317"      # HTTP collector accept OpenTelemetry Protocol (OTLP) over gRPC
+      - "4318:4318"      # HTTP collector accept OpenTelemetry Protocol (OTLP) over HTTP
+      - "14268:14268"    # HTTP collector accept jaeger.thrift
 
   ui:
     image: target/strelka-ui:latest
@@ -104,3 +104,5 @@ services:
       - POSTGRESQL_USERNAME=postgres
     networks:
       - net
+    ports:
+      - "5432:5432"

--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -123,7 +123,7 @@ class ScanYara(strelka.Scanner):
         """
         # Retrieve location of YARA rules.
         location = options.get("location", "/etc/strelka/yara/")
-        compiled = options.get("compiled")
+        compiled = options.get("compiled", {"enabled": False})
 
         try:
             # Load compiled YARA rules from a file.

--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 
 import yara
@@ -39,6 +40,10 @@ class ScanYara(strelka.Scanner):
         self.compiled_yara = None
         self.loaded_configs = False
         self.rules_loaded = 0
+
+        self.warn_user = False
+        self.warned_user = False
+        self.warn_message = ""
 
     def scan(self, data, file, options, expire_at):
         """Scans the provided data with YARA rules.
@@ -133,6 +138,7 @@ class ScanYara(strelka.Scanner):
                 )
         except yara.Error as e:
             self.flags.append(f"compiled_load_error_{e}")
+            self.warn_user = True
 
         try:
             # Compile YARA rules from a directory.
@@ -153,14 +159,39 @@ class ScanYara(strelka.Scanner):
                     self.compiled_yara = yara.compile(filepath=location)
                 else:
                     self.flags.append("yara_location_not_found")
-        except yara.Error as e:
-            self.flags.append(f"compiling_error_general_{e}")
+                    self.warn_user = True
+                    self.warn_message = "YARA Location Not Found"
+
         except yara.SyntaxError as e:
             self.flags.append(f"compiling_error_syntax_{e}")
+            self.warn_user = True
+            self.warn_message = str(e)
+
+        except yara.Error as e:
+            self.flags.append(f"compiling_error_general_{e}")
+            self.warn_user = True
+            self.warn_message = str(e)
 
         # Set the total rules loaded.
         if self.compiled_yara:
             self.rules_loaded = len(list(self.compiled_yara))
+
+        if not self.compiled_yara:
+            if not self.warned_user and self.warn_user:
+                logging.warning(
+                    "\n"
+                    "*************************************************\n"
+                    "* WARNING: YARA File Loading Issue Detected     *\n"
+                    "*************************************************\n"
+                    "There was an issue loading the compiled YARA file. Please check that all YARA rules can be\n"
+                    "successfully compiled. Additionally, verify the 'ScanYara' configuration in Backend.yaml to\n"
+                    "ensure the targeted path is correct. This issue needs to be resolved for proper scanning\n"
+                    "functionality.\n"
+                    "\n"
+                    f"Error: {self.warn_message}\n"
+                    "*************************************************\n"
+                )
+                self.warned_user = True
 
     def extract_match_hex(self, rule, offset, matched_string, data, offset_padding=32):
         """

--- a/src/python/strelka/tests/test_scan_yara.py
+++ b/src/python/strelka/tests/test_scan_yara.py
@@ -50,7 +50,7 @@ def test_scan_bad_yara(mocker):
     test_scan_event = {
         "elapsed": mock.ANY,
         "flags": [
-            'compiling_error_general_/strelka/strelka/tests/fixtures/test_elk_linux_torte.yara(31): undefined identifier "is__elf"',
+            'compiling_error_syntax_/strelka/strelka/tests/fixtures/test_elk_linux_torte.yara(31): undefined identifier "is__elf"',
             "no_rules_loaded",
         ],
         "matches": [],


### PR DESCRIPTION
**Describe the change**
This PR makes a couple changes that assists in YARA loading issues:

1) Ensures that if a `backend.yml` exists without a specific key (e.g., yara.compiled), a default is used to prevent an unhandled exception.

YARA failure prior to fix:

```
strelka-backend-1      | 2023-11-13 18:08:22 - [ERROR] root [strelka.scan_wrapper]: ScanYara: unhandled exception while scanning uid a197de79-b500-4cb0-ae4f-64a14f7c54e6 (see traceback below)
strelka-backend-1      | Traceback (most recent call last):
strelka-backend-1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/strelka.py", line 779, in scan_wrapper
strelka-backend-1      |     self.scan(data, file, options, expire_at)
strelka-backend-1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/scanners/scan_yara.py", line 58, in scan
strelka-backend-1      |     self.load_yara_rules(options)
strelka-backend-1      |   File "/usr/local/lib/python3.10/dist-packages/strelka-0.0.0-py3.10.egg/strelka/scanners/scan_yara.py", line 130, in load_yara_rules
strelka-backend-1      |     if compiled.get("enabled", False):
strelka-backend-1      | AttributeError: 'NoneType' object has no attribute 'get'
```

2) A warning is provided to the user if an issue loading YARA rules is observed. This prevents the user from needing prior knowledge of needing to look at `yara.flags` for potential exceptions.

```
backend-1      | *************************************************
backend-1      | * WARNING: YARA File Loading Issue Detected     *
backend-1      | *************************************************
backend-1      | There was an issue loading the compiled YARA file. Please check that all YARA rules can be
backend-1      | successfully compiled. Additionally, verify the 'ScanYara' configuration in Backend.yaml to
backend-1      | ensure the targeted path is correct. This issue needs to be resolved for proper scanning
backend-1      | functionality.
backend-1      | 
backend-1      | Error: /etc/strelka/yara/rules.yara(38): undefined identifier "is__elf"
backend-1      | *************************************************
```

3) Added a recommendation to the `README` which recommends users precompile their YARA rules prior to Strelka start.


**Describe testing procedures**

No unexpected errors / warnings were thrown and files were successfully scanned.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
