### PR TITLE
Bugfix: Add fix for SSL CA Bundle Verification Issue

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -291,11 +291,12 @@ func main() {
 		if !*locallog && *kafkalog {
 			log.Printf("Creating new Kafka producer.")
 			p, err := kafka.NewProducer(&kafka.ConfigMap{
-				"bootstrap.servers":        conf.Broker.Bootstrap,
-				"security.protocol":        conf.Broker.Protocol,
-				"ssl.certificate.location": conf.Broker.Certlocation,
-				"ssl.key.location":         conf.Broker.Keylocation,
-				"ssl.ca.location":          conf.Broker.Calocation,
+				"bootstrap.servers":                     conf.Broker.Bootstrap,
+				"security.protocol":                     conf.Broker.Protocol,
+				"ssl.certificate.location":              conf.Broker.Certlocation,
+				"ssl.key.location":                      conf.Broker.Keylocation,
+				"ssl.ca.location":                       conf.Broker.Calocation,
+				"ssl.endpoint.identification.algorithm": "none",
 			})
 			if err != nil {
 				log.Fatalf("FAILED TO CREATE KAFKA PRODUCER: ERROR %v", err)


### PR DESCRIPTION
**Describe the change**
After the recent upgrade to Confluent Kafka Go v2, it was found that the ssl.endpoint.identification.algorithm configuration option [defaults to https](https://github.com/confluentinc/librdkafka/issues/4349). In order to maintain the behavior that has already been tested with this producer, this configuration option needs to be set to "none" in order to bypass this default. This PR makes the above change. 

**Describe testing procedures**
Kafka producer was tested with existing broker to verify config change resolves the issue. Default logging was also tested using locally built containers to ensure that normal behavior of local logging did not change. 

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
