### PR TITLE
Fix for Invalid Stripping for Email Message ID Parsing

### DIFF
--- a/src/python/strelka/scanners/scan_email.py
+++ b/src/python/strelka/scanners/scan_email.py
@@ -125,7 +125,9 @@ class ScanEmail(strelka.Scanner):
                     + ".000Z"
                 )
                 self.event["message_id"] = str(
-                    parsed_eml["header"]["header"]["message-id"][0][1:-1]
+                    parsed_eml["header"]["header"]["message-id"][0]
+                    .lstrip("<")
+                    .rstrip(">")
                 )
                 if "received_domain" in parsed_eml["header"]:
                     self.event["received_domain"] = parsed_eml["header"][

--- a/src/python/strelka/tests/test_scan_email.py
+++ b/src/python/strelka/tests/test_scan_email.py
@@ -44,7 +44,7 @@ def test_scan_email(mocker):
         "to": unordered(["baz.quk@example.com"]),
         "from": "foo.bar@example.com",
         "date_utc": "2022-12-21T02:29:49.000Z",
-        "message_id": "S7PR03MB5640AD212589DFB7CE58D90CFBEB9@DS7PR03MB5640.namprd03.prod.outlook.co",
+        "message_id": "DS7PR03MB5640AD212589DFB7CE58D90CFBEB9@DS7PR03MB5640.namprd03.prod.outlook.com",
         "received_domain": unordered(
             [
                 "ch2pr03mb5366.namprd03.prod.outlook.com",


### PR DESCRIPTION
**Describe the change**
This change modifies the `ScanEmail` class in the strelka scanner module. The update involves a minor alteration where the `message_id` field is extracted from the email header without the surrounding angle brackets (<>) by using `.strip` rather than simply the removal of the first and last character.

**Describe testing procedures**
`scan_test_email.py` was modified to pass based on the change


**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
