### PR TITLE
ScanPe Fix for Dictionary / Flag Type Change (Fix for #433)

### DIFF
--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -402,13 +402,13 @@ class ScanPe(strelka.Scanner):
             return
 
         if rich_dict := parse_rich(pe):
-            if type(rich_dict) is str:
+            if type(rich_dict) is not str:
                 self.event["rich"] = rich_dict
             else:
                 self.flags.append(rich_dict)
 
         if cert_dict := parse_certificates(data):
-            if type(cert_dict) is str:
+            if type(cert_dict) is not str:
                 self.event["security"] = cert_dict
             else:
                 self.flags.append(cert_dict)

--- a/src/python/strelka/tests/test_scan_pe.py
+++ b/src/python/strelka/tests/test_scan_pe.py
@@ -15,8 +15,7 @@ def test_scan_pe(mocker):
 
     test_scan_event = {
         "elapsed": mock.ANY,
-        "flags": [],
-        "security": "no_certs_found",
+        "flags": ["no_certs_found"],
         "total": {"libraries": 0, "resources": 2, "sections": 2, "symbols": 0},
         "summary": {
             "resource_md5": unordered(


### PR DESCRIPTION
**Describe the change**
As noted in #433, two conditionals were flipped to incorrect logic, causing a mix of types in string and dictionary fields. This change fixes those conditionals to be more accurate to the original intent.

Closes #433.

**Describe testing procedures**
Reran tests with valid output

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
