### PR TITLE
Fix bad filestream comment

### DIFF
--- a/src/go/cmd/strelka-filestream/main.go
+++ b/src/go/cmd/strelka-filestream/main.go
@@ -202,7 +202,7 @@ func main() {
 					continue
 				}
 
-				// Ignore older files
+				// Temporarily ignore newly written files
 				if t.Sub(fi.ModTime()) < conf.Delta {
 					continue
 				}


### PR DESCRIPTION
Comment documented an exclusion in the wrong direction, old files vs. new files via Delta.

This change is a single comment only and should not need testing.


