### PR TITLE
ScanEmail: Restrict Access in WeasyPrint

### DIFF
--- a/src/python/strelka/scanners/scan_email.py
+++ b/src/python/strelka/scanners/scan_email.py
@@ -467,7 +467,7 @@ def local_fetch_only(url, *args, **kwargs):
         # Allow base64 encoded data or local file paths
         if parsed_url.scheme in ("data", "file", ""):
             return default_url_fetcher(url, *args, **kwargs)
-    except Exception as e:
+    except Exception:
         pass
 
     # Block all other URLs (http, https, ftp, IP addresses, etc.)

--- a/src/python/strelka/scanners/scan_email.py
+++ b/src/python/strelka/scanners/scan_email.py
@@ -467,7 +467,7 @@ def local_fetch_only(url, *args, **kwargs):
         # Allow base64 encoded data or local file paths
         if parsed_url.scheme in ("data", "file", ""):
             return default_url_fetcher(url, *args, **kwargs)
-    except:
+    except Exception as e:
         pass
 
     # Block all other URLs (http, https, ftp, IP addresses, etc.)

--- a/src/python/strelka/tests/fixtures/test_external_addresses.eml
+++ b/src/python/strelka/tests/fixtures/test_external_addresses.eml
@@ -1,0 +1,40 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Test Email with HTML Content and External Resources
+Date: Tue, 1 Jun 2021 12:34:56 -0700
+Message-ID: <test@example.com>
+Content-Type: multipart/related; boundary="000000000000b3d4e605c8491234"
+
+--000000000000b3d4e605c8491234
+Content-Type: multipart/alternative; boundary="000000000000b3d4e605c8495678"
+
+--000000000000b3d4e605c8495678
+Content-Type: text/plain; charset="UTF-8"
+
+This is a test email with plain text content.
+
+--000000000000b3d4e605c8495678
+Content-Type: text/html; charset="UTF-8"
+
+<html>
+  <body>
+    <p>This is a <b>test email</b> with HTML content.</p>
+    <p>Here are some external resources:</p>
+    <img src="http://example.com/testimage.png">
+    <img src="ftp://example.com/testimage.png">
+    <img src="http://192.168.1.2/testimage.png">
+    <img src="cid:testimage">
+  </body>
+</html>
+
+--000000000000b3d4e605c8495678--
+
+--000000000000b3d4e605c8491234
+Content-Type: image/png; name="testimage.png"
+Content-Disposition: inline; filename="testimage.png"
+Content-ID: <testimage>
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/gtLZ4cAAAAASUVORK5CYII=
+
+--000000000000b3d4e605c8491234--

--- a/src/python/strelka/tests/test_scan_email.py
+++ b/src/python/strelka/tests/test_scan_email.py
@@ -1,4 +1,3 @@
-import base64
 from pathlib import Path
 from unittest import TestCase, mock
 


### PR DESCRIPTION
## Add `local_fetch_only` Function to Restrict External Network Access in WeasyPrint

### Description

This PR introduces a custom URL fetcher function, `local_fetch_only`, for WeasyPrint. The purpose of this function is to prevent any external network access during the fetching process. It allows only local file paths, base64 encoded data, and relative URLs. All other URLs, including HTTP, HTTPS, FTP, and IP addresses, are blocked. Previously, external calls _were_ observed for things like CSS files and such. This should be _restricted_.

### Implementation

The `local_fetch_only` function is designed to:

- **Allow Base64 Encoded Data**: URLs with the `data` scheme.
- **Allow Local File Paths**: URLs with the `file` scheme.
- **Allow Relative URLs**: URLs without a scheme.

For all other URL schemes (e.g., `http`, `https`, `ftp`), the function returns an empty response, effectively blocking the request.

### Code

```python
from urllib.parse import urlparse
from weasyprint import default_url_fetcher

def local_fetch_only(url, *args, **kwargs):
    """
    Custom URL fetcher for WeasyPrint that prevents any external network access.

    This function allows only local file paths, base64 encoded data, and relative URLs. It blocks all other URLs,
    including HTTP, HTTPS, FTP, and IP addresses, ensuring that no external network access occurs during the fetching
    process.

    Args:
        url (str): The URL to fetch.
        *args: Additional positional arguments.
        **kwargs: Additional keyword arguments.

    Returns:
        dict: A dictionary containing an empty string for 'string', 'text/plain' for 'mime_type', and 'utf8' for 'encoding'
              if the URL is blocked. Otherwise, it uses the default fetcher for local resources.
    """
    parsed_url = urlparse(url)

    # Allow base64 encoded data, local file paths, or relative URLs
    if parsed_url.scheme in ('data', 'file', ''):
        return default_url_fetcher(url, *args, **kwargs)

    # Block all other URLs (http, https, ftp, IP addresses, etc.)
    return {
        'string': '',
        'mime_type': 'text/plain',
        'encoding': 'utf8'
    }
```

### Reasoning
The primary motivation for this implementation is security. By blocking external network requests, we ensure that WeasyPrint cannot inadvertently leak data or fetch resources from untrusted sources. This will prevent some resources from loading but ultimately is safer.

### Control
Allowing only local file paths and base64 encoded data provides fine-grained control over the resources that can be accessed. Relative URLs are permitted to ensure that internal resources can still be referenced without specifying the full URL.

### Use Cases


1. Base64 Data URL
```html
<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/gtLZ4cAAAAASUVORK5CYII=">
```
2. Local File URL
```html
<img src="file:///path/to/local/image.png">
```

3. Relative URL
```python
<img src="/images/local_image.png">
```


**Describe testing procedures**
An additional test with an `eml` file was created to test the retrieval of external (fake) resources. This test will produce a thumbnail of an image without additional <img> tags

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
