### PR TITLE
Adding Pull Policy to Latest Images

### DIFF
--- a/build/docker-compose-no-build.yaml
+++ b/build/docker-compose-no-build.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 
 networks:
   net:
@@ -10,6 +10,7 @@ services:
   frontend:
     image: target/strelka-frontend:latest
     command: strelka-frontend
+    pull_policy: always
     ports:
       - 57314:57314  # must match the port in frontend.yaml
     networks:
@@ -25,6 +26,7 @@ services:
   backend:
     image: target/strelka-backend:latest
     command: strelka-backend
+    pull_policy: always
     shm_size: 512mb  # increase as necessary, required for some scanners
     networks:
       - net
@@ -77,6 +79,7 @@ services:
 
   ui:
     image: target/strelka-ui:latest
+    pull_policy: always
     environment:
       - DATABASE_HOST=postgresdb
       - DATABASE_NAME=strelka_ui

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 
 networks:
   net:
@@ -83,6 +83,7 @@ services:
 
   ui:
     image: target/strelka-ui:latest
+    pull_policy: always
     environment:
       - DATABASE_HOST=postgresdb
       - DATABASE_NAME=strelka_ui


### PR DESCRIPTION
## Changes

### Summary
This pull request adds the `pull_policy: always` option to ensure that Docker Compose always pulls the latest images for the following services:
- `frontend`  (`./build/docker-compose-no-build.yaml`)
- `backend`  (`./build/docker-compose-no-build.yaml`)
- `ui` (`./build/docker-compose.yaml` and `./build/docker-compose-no-build.yaml`)

**Note: This change requires Docker Compose version 3.7 or later.**

### Issues Fixed
Previously, if a user had an older image in their repository, docker would start up the preexisting image, even if it wasn't necessarily the latest image in the remote repository.

### Motivation and Context
To ensure that the latest versions of the images are always used, reducing the risk of running outdated versions.

## Testing

### Testing Configurations
- Docker Compose version: 3.7+
- Services tested: `frontend`, `backend`, `ui`

### Steps to Reproduce
1. Update Docker Compose file to include `pull_policy: always`.
2. Run `docker-compose pull` to pull the latest images.
3. Run `docker-compose up -d` to start the services.
4. Verify that the latest images are being used by inspecting the running containers.

## Sample Output
N/A - This change does not modify the output of Strelka.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
