### PR TITLE
Updating Docker Compose Reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ echo 'include "./rules/index.yar"' > configs/python/backend/yara/rules.yara
 **Note**: You can skip the `go build` process and use the `Strelka UI` at `http://0.0.0.0:9980` to analyze files.
 
 ```bash
-docker-compose -f build/docker-compose-no-build.yaml up -d && \
+docker compose -f build/docker-compose-no-build.yaml up -d && \
 go build github.com/target/strelka/src/go/cmd/strelka-oneshot
 ```
 
@@ -65,8 +65,8 @@ go build github.com/target/strelka/src/go/cmd/strelka-oneshot
 **Note**: You can skip the `go build` process and use the `Strelka UI` at `http://0.0.0.0:9980` to analyze files.
 
 ```bash
-docker-compose -f build/docker-compose.yaml build && \
-docker-compose -f build/docker-compose.yaml up -d && \
+docker compose -f build/docker-compose.yaml build && \
+docker compose -f build/docker-compose.yaml up -d && \
 go build github.com/target/strelka/src/go/cmd/strelka-oneshot
 ```
 


### PR DESCRIPTION
**Describe the change**
Updating docker-compose to docker compose in README references as the syntax has changed. We will have to review for compatibility (perhaps just have both commands as options)

**Describe testing procedures**
None yet

**Sample output**
N/A

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
