### PR TITLE
Added Docker Restart Policies to all docker-compose files so that Strelka restarts in a fully running state.

### DIFF
--- a/build/docker-compose-no-build.yaml
+++ b/build/docker-compose-no-build.yaml
@@ -54,12 +54,14 @@ services:
   coordinator:
     image: redis:alpine
     command: redis-server --save "" --appendonly no  # alt: use config file via volume mapping
+    restart: unless-stopped
     networks:
       - net
 
   gatekeeper:
     image: redis:alpine
     command: redis-server --save "" --appendonly no --maxmemory-policy allkeys-lru  # alt: use config file via volume mapping
+    restart: unless-stopped
     networks:
       - net
 
@@ -79,6 +81,7 @@ services:
 
   ui:
     image: target/strelka-ui:latest
+    restart: unless-stopped
     pull_policy: always
     environment:
       - DATABASE_HOST=postgresdb
@@ -95,6 +98,7 @@ services:
 
   postgresdb:
     image: docker.io/bitnami/postgresql:11
+    restart: unless-stopped
     environment:
       - POSTGRESQL_DATABASE=strelka_ui
       - POSTGRESQL_PASSWORD=postgres

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -58,12 +58,14 @@ services:
   coordinator:
     image: redis:alpine
     command: redis-server --save "" --appendonly no  # alt: use config file via volume mapping
+    restart: unless-stopped
     networks:
       - net
 
   gatekeeper:
     image: redis:alpine
     command: redis-server --save "" --appendonly no --maxmemory-policy allkeys-lru  # alt: use config file via volume mapping
+    restart: unless-stopped
     networks:
       - net
 
@@ -83,6 +85,7 @@ services:
 
   ui:
     image: target/strelka-ui:latest
+    restart: unless-stopped
     pull_policy: always
     environment:
       - DATABASE_HOST=postgresdb
@@ -104,6 +107,7 @@ services:
 
   postgresdb:
     image: docker.io/bitnami/postgresql:11
+    restart: unless-stopped
     environment:
       - POSTGRESQL_DATABASE=strelka_ui
       - POSTGRESQL_PASSWORD=postgres


### PR DESCRIPTION
**Describe the change**
Added the `unless-stopped` Restart Policy to the coordinator, gatekeep, ui, and postgresdb docker containers in both the docker-compose.yaml and docker-compose-no-build.yaml files to match the other docker containers in these docker compose files. If a user restarts docker or their server before this change then only then only the jaeger, frontend, backend, and manager docker containers would restart leaving Strelka in a bad state.

**Describe testing procedures**
Re-deployed a oneshot Strelka instance with this new docker-compose file and ran multiple files through the front end UI which all came back with normal results

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
