### PR TITLE
Upgrading 7zip to version 24.09

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -21,10 +21,6 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --create-home --shell /bin/bash $USERNAME
 
-# Set up package pinning for release (mantic 23.10, 7zip 23.01+dfsg-2)
-COPY ./build/python/backend/pin.pref /etc/apt/preferences.d/pin.pref
-COPY ./build/python/backend/mantic.list /etc/apt/sources.list.d/mantic.list
-
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 # Install build packages
@@ -61,7 +57,6 @@ ENV PATH=$PATH:/opt/zeek/bin
 # Install runtime packages
 RUN apt-get -q update && \
     apt-get install -q -y --no-install-recommends \
-    7zip \
     antiword \
     binwalk \
     libarchive-dev \
@@ -90,6 +85,11 @@ RUN apt-get -q update && \
     perl Makefile.PL && \
     make -s && \
     make -s install && \
+# Download and move binary for 7z 24.09
+    cd /tmp/ && \
+    curl -OL https://7-zip.org/a/7z2409-linux-x64.tar.xz &&\
+    tar -xf 7z2409-linux-x64.tar.xz &&\
+    cp 7zz /usr/local/bin && \
 # Install YARA
     cd /tmp/ && \
     curl -OL https://github.com/VirusTotal/yara/archive/v$YARA_VERSION.tar.gz && \

--- a/build/python/backend/mantic.list
+++ b/build/python/backend/mantic.list
@@ -1,1 +1,0 @@
-deb [arch=amd64] http://old-releases.ubuntu.com/ubuntu mantic main restricted universe multiverse

--- a/build/python/backend/pin.pref
+++ b/build/python/backend/pin.pref
@@ -1,7 +1,0 @@
-Package: 7zip
-Pin: version 23.01+dfsg-3
-Pin-Priority: 1001
-
-Package: *
-Pin: release n=mantic
-Pin-Priority: 100

--- a/poetry.lock
+++ b/poetry.lock
@@ -3098,23 +3098,19 @@ web = ["flask", "regex", "requests"]
 
 [[package]]
 name = "setuptools"
-version = "74.1.2"
+version = "69.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-74.1.2-py3-none-any.whl", hash = "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308"},
-    {file = "setuptools-74.1.2.tar.gz", hash = "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"},
+    {file = "setuptools-69.1.0-py3-none-any.whl", hash = "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"},
+    {file = "setuptools-69.1.0.tar.gz", hash = "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.5.2)"]
-core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.11.*)", "pytest-mypy"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "signify"
@@ -3522,4 +3518,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<=3.12"
-content-hash = "59352bc260a86a24fdf5e59c900e5064864c6c9025f3813d072f2809129bd1a2"
+content-hash = "952023564d35ec54d409d7275b8b4fd35412f753d463d0d6f2194ff22b4725bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ entropy = { git = "https://github.com/jshlbrd/python-entropy.git", rev = "a49f1a
 speakeasy-emulator = { git = "https://github.com/mandiant/speakeasy.git", rev = "1cb52a92ab4bae3659b0f8db4ed29f591d932c88" }
 zipp = "^3.20.1"
 certifi = "^2024.8.30"
+setuptools = "69.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/python/strelka/scanners/scan_dmg.py
+++ b/src/python/strelka/scanners/scan_dmg.py
@@ -128,7 +128,7 @@ class ScanDmg(strelka.Scanner):
         try:
             output_lines = output_7zip.splitlines()
 
-            # 7-Zip (z) 23.01 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
+            # 7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
             regex_7zip_version = re.compile(r"^7-Zip[^\d]+(\d+\.\d+)")
 
             # --/----

--- a/src/python/strelka/scanners/scan_seven_zip.py
+++ b/src/python/strelka/scanners/scan_seven_zip.py
@@ -204,7 +204,7 @@ class ScanSevenZip(strelka.Scanner):
 
         output_lines = output_7zip.splitlines()
 
-        # 7-Zip (z) 23.01 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
+        # 7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
         regex_7zip_version = re.compile(r"^7-Zip[^\d]+(\d+\.\d+)")
 
         # --/----

--- a/src/python/strelka/scanners/scan_udf.py
+++ b/src/python/strelka/scanners/scan_udf.py
@@ -125,7 +125,7 @@ class ScanUdf(strelka.Scanner):
         try:
             output_lines = output_7zip.splitlines()
 
-            # 7-Zip (z) 23.01 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
+            # 7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
             regex_7zip_version = re.compile(r"^7-Zip[^\d]+(\d+\.\d+)")
 
             # --/----

--- a/src/python/strelka/scanners/scan_vhd.py
+++ b/src/python/strelka/scanners/scan_vhd.py
@@ -125,7 +125,7 @@ class ScanVhd(strelka.Scanner):
         try:
             output_lines = output_7zip.splitlines()
 
-            # 7-Zip (z) 23.01 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
+            # 7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-12-26
             regex_7zip_version = re.compile(r"^7-Zip[^\d]+(\d+\.\d+)")
 
             # --/----

--- a/src/python/strelka/tests/test_scan_dmg.py
+++ b/src/python/strelka/tests/test_scan_dmg.py
@@ -43,7 +43,7 @@ def test_scan_dmg_compressed(mocker):
             },
         ],
         "meta": {
-            "7zip_version": "23.01",
+            "7zip_version": "24.09",
             "partitions": [
                 {
                     "path": mock.ANY,
@@ -102,7 +102,7 @@ def test_scan_dmg_readonly(mocker):
             },
         ],
         "meta": {
-            "7zip_version": "23.01",
+            "7zip_version": "24.09",
             "partitions": [
                 {"path": mock.ANY, "type": "Dmg"},
                 {"path": "4.apfs"},
@@ -183,7 +183,7 @@ def test_scan_dmg_readwrite(mocker):
             },
         ],
         "meta": {
-            "7zip_version": "23.01",
+            "7zip_version": "24.09",
             "partitions": [
                 {"path": mock.ANY, "type": "GPT"},
                 {"path": "0.disk image.apfs", "file_system": "APFS"},

--- a/src/python/strelka/tests/test_scan_seven_zip.py
+++ b/src/python/strelka/tests/test_scan_seven_zip.py
@@ -38,7 +38,7 @@ def test_scan_sevenzip(mocker):
             },
         ],
         "hidden_dirs": ["hidden"],
-        "meta": {"7zip_version": "23.01"},
+        "meta": {"7zip_version": "24.09"},
     }
 
     scanner_event = run_test_scan(
@@ -84,7 +84,7 @@ def test_scan_sevenzip_wordlist(mocker):
             },
         ],
         "hidden_dirs": ["hidden"],
-        "meta": {"7zip_version": "23.01"},
+        "meta": {"7zip_version": "24.09"},
         "cracked_password": b"password",
     }
 
@@ -137,7 +137,7 @@ def test_scan_sevenzip_wordlist_filenames(mocker):
             },
         ],
         "hidden_dirs": ["hidden"],
-        "meta": {"7zip_version": "23.01"},
+        "meta": {"7zip_version": "24.09"},
         "cracked_password": b"password",
     }
 
@@ -169,7 +169,7 @@ def test_scan_sevenzip_nocrack_filenames(mocker):
         "total": {"files": 0, "extracted": 0},
         "files": [],
         "hidden_dirs": [],
-        "meta": {"7zip_version": "23.01"},
+        "meta": {"7zip_version": "24.09"},
     }
 
     scanner_event = run_test_scan(
@@ -211,7 +211,7 @@ def test_scan_sevenzip_msi_filenames(mocker):
             },
         ],
         "hidden_dirs": [],
-        "meta": {"7zip_version": "23.01"},
+        "meta": {"7zip_version": "24.09"},
     }
 
     scanner_event = run_test_scan(
@@ -258,7 +258,7 @@ def test_scan_sevenzip_brute(mocker):
             },
         ],
         "hidden_dirs": ["hidden"],
-        "meta": {"7zip_version": "23.01"},
+        "meta": {"7zip_version": "24.09"},
         "cracked_password": b"aaa",
         "performance": {
             "keyspace": {"min_length": 1, "max_length": 3},

--- a/src/python/strelka/tests/test_scan_udf.py
+++ b/src/python/strelka/tests/test_scan_udf.py
@@ -24,7 +24,7 @@ def test_scan_udf(mocker):
         ],
         "hidden_dirs": [],
         "meta": {
-            "7zip_version": "23.01",
+            "7zip_version": "24.09",
             "partitions": [
                 {
                     "path": mock.ANY,

--- a/src/python/strelka/tests/test_scan_vhd.py
+++ b/src/python/strelka/tests/test_scan_vhd.py
@@ -38,7 +38,7 @@ def test_scan_vhd(mocker):
             "$RECYCLE.BIN/S-1-5-21-3712961497-200595429-3248382696-1000",
         ],
         "meta": {
-            "7zip_version": "23.01",
+            "7zip_version": "24.09",
             "partitions": [
                 {"path": mock.ANY, "type": "GPT"},
                 {"path": "0.Basic data partition.ntfs", "file_system": "Windows BDP"},
@@ -96,7 +96,7 @@ def test_scan_vhdx(mocker):
             "$RECYCLE.BIN/S-1-5-21-3712961497-200595429-3248382696-1000",
         ],
         "meta": {
-            "7zip_version": "23.01",
+            "7zip_version": "24.09",
             "partitions": [
                 {
                     "path": mock.ANY,


### PR DESCRIPTION
**Describe the change**
In response to [CVE-2024-11477](https://nvd.nist.gov/vuln/detail/CVE-2024-11477) published on 11/22, this PR updates the version of 7zip from 23.01 to 24.09 in order to patch this vulnerability. Though, it should be noted that this vulnerability is likely unreachable in the current Strelka code execution.

The update to 24.09 means that we are no longer dependent on the archived Ubuntu Mantic version, so the mantic.list and pin.fref files and references were removed. Finally, updated all test cases to reflect the version change. No change is made to the functionality or extraction of metadata due to the change in 7zip versions. 

Additionally re-added setuptools as a Poetry dependency as a stop gap in the short term to stabilize the inconsistent nightly Github workflows while a more permanent solution might be found. 

**Describe testing procedures**
Tested with a local builds and ensured that all test cases ran successfully. 

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
