### PR TITLE
ScanTLSH diffxlen Update

### DIFF
--- a/src/python/strelka/scanners/scan_tlsh.py
+++ b/src/python/strelka/scanners/scan_tlsh.py
@@ -74,7 +74,7 @@ class ScanTlsh(strelka.Scanner):
             for tlsh_hash in tlsh_hashes:
                 try:
                     # Calculate the difference score between the file hash and the rule hash
-                    score = tlsh.diff(tlsh_file, tlsh_hash)
+                    score = tlsh.diffxlen(tlsh_file, tlsh_hash)
                 except ValueError:
                     self.flags.append(f"bad_tlsh: {tlsh_hash}")
                     continue


### PR DESCRIPTION
**Describe the change**
Discovered by @ronbarrey, there is a significant difference between `diff` to `diffxlen` hashing functions in the library that creates the TLSH hashes in scanTLSH. The `diffxlen` function compares the data and ignores the length of a file, where the existing `diff` function call will compare the data and the length of a file. 

**Describe testing procedures**
Using a padded warzone payload, they discovered that there was significantly better attribution to malware family similarities using `diffxlen` over `diff`, as seen below:

`diff` results:
![diff results](https://github.com/user-attachments/assets/3bef4fda-4ecd-430e-b848-e4073623232d)

`diffxlen` results:
![diffxlen](https://github.com/user-attachments/assets/3562b8dc-0a6b-4a0e-953a-4f0bdb57f608)

**Sample output**
None, though detection is improved through `diffxlen` usage. 

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
