### PR TITLE
Docx Classification Update

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -90,6 +90,7 @@ scanners:
     - positive:
         flavors:
           - 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+          - "docx_file"
       priority: 5
       options:
         extract_text: False
@@ -166,6 +167,7 @@ scanners:
           - 'image/avif'
           - 'image/heic'
           - 'image/heif'
+          - "docx_file"
       priority: 5
   'ScanFooter':
     - positive:

--- a/configs/python/backend/taste/taste.yara
+++ b/configs/python/backend/taste/taste.yara
@@ -865,6 +865,19 @@ rule vb_file {
 
 // Text Files
 
+rule docx_file
+{
+	meta:
+	    author = "Niels Warnars"
+	    type = "document"
+		description = "Word 2007 file format detection"
+	strings:
+		$header = { 50 4B 03 04 }
+		$str = "document.xml"
+	condition:
+	   $header at 0 and $str
+}
+
 rule hta_file {
     meta:
         type = "text"


### PR DESCRIPTION
**Describe the change**
It was found that Strelka was not properly classifying docx files, which could lead to ScanDocx/ScanExif not processing files that the scanners should pick up. This PR adds in a simple yara rule "docx_file" to help classifying docx files which are currently coming through as octet-stream. Added the rule to the flavors of both ScanExif and ScanDocx.

**Describe testing procedures**
Tested to ensure that local build still runs successfully and all tests continue to pass. 

**Sample output**
 N/A, though more files should now be picked up by ScanDocx/ScanExif 

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
