### PR TITLE
Configurable Filestream Client Name

### DIFF
--- a/configs/go/filestream/filestream.yaml
+++ b/configs/go/filestream/filestream.yaml
@@ -1,4 +1,5 @@
 conn:
+  client: 'name of your custom client, historically go-filestream'
   server: '127.0.0.1:57314'
   cert: ''
   timeout:

--- a/src/go/cmd/strelka-filestream/main.go
+++ b/src/go/cmd/strelka-filestream/main.go
@@ -106,7 +106,7 @@ func main() {
 		log.Println("responses will be discarded")
 	}
 
-	client := "go-filestream"
+	client := conf.Conn.Client
 	if conf.Client != "" {
 		client = conf.Client
 	}

--- a/src/go/pkg/structs/structs.go
+++ b/src/go/pkg/structs/structs.go
@@ -10,6 +10,7 @@ import (
 
 // defines structures used in configuration files
 type ConfConn struct {
+	Client  string      //required
 	Server  string      // required
 	Cert    string      // required
 	Timeout ConfTimeout // required


### PR DESCRIPTION
**Describe the change**
The filestream client name is currently hard coded as 'go-filestream'. This PR makes this client name configurable via an addition to the existing filestream.yaml configuration file. This is useful as it helps differentiates clients coming sending data to centralizated Strelka cluster from different filestream clients. 

**Describe testing procedures**
Tested with a local build to ensure that the client name is passed along with the requests sent to the cluster. 

**Sample output**
N/A, just allows for the existing client name to be more easily changed from the default 'go-filestream' without directly changing the code and rebuilding the image. 

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
