### PR TITLE
Adding Validation to ScanURL

### DIFF
--- a/src/python/strelka/scanners/scan_url.py
+++ b/src/python/strelka/scanners/scan_url.py
@@ -59,8 +59,8 @@ class ScanUrl(strelka.Scanner):
                 ).decode()
 
                 # Check to see if there are nonURL chars stil in URL:
-                nonURL_regex_pattern = '[\^&\(\)+\[\]{}\|"]'
-                split_uls = re.split(nonURL_regex_pattern, strip_trailing_url)
+                nonurl_regex_pattern = r'[\^&\(\)+\[\]{}\|"]'
+                split_uls = re.split(nonurl_regex_pattern, strip_trailing_url)
                 for split_result in split_uls:
                     if (
                         validators.url(split_result)

--- a/src/python/strelka/tests/test_scan_url.py
+++ b/src/python/strelka/tests/test_scan_url.py
@@ -18,7 +18,6 @@ def test_scan_url_text(mocker):
         "flags": [],
         "urls": unordered(
             [
-                "example.com",
                 "http://foobar.example.com",
                 "https://barfoo.example.com",
                 "ftp://barfoo.example.com",


### PR DESCRIPTION
**Describe the change**
This PR does additional regex matching to pull out URLs matched by the original regex pattern, and then uses the python validators library to ensure the extracted URL matches the widely accepted URL pattern.

The secondary regex matching was chosen by splitting the generated url string by those characters deemed unsafe in the Internet Engineering Task Force (IETF) [RCF 1738](https://datatracker.ietf.org/doc/html/rfc1738) and excluding the split characters.

**Describe testing procedures**
Tested with local build to ensure that tests pass and entire application builds successfully. 

**Sample output**
No change to output, though note that under the above stipulations, one of the original results "example.com" is not considered a valid URL anymore, and has been removed from the scanURL test as it is now invalid.

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
