### PR TITLE
Modify test_scan_event data sizes

### DIFF
--- a/src/python/strelka/tests/test_scan_clamav.py
+++ b/src/python/strelka/tests/test_scan_clamav.py
@@ -36,8 +36,8 @@ def test_scan_clamav(mocker):
     """
     retrieve_signatures()
     test_scan_event = {
-        "Data read": "0.51 MB (ratio 1.06",
-        "Data scanned": "0.54 MB",
+        "Data read": "526.71 KiB (ratio 1.06",
+        "Data scanned": "557.96 KiB",
         "End Date": mock.ANY,
         "Engine version": mock.ANY,
         "Infected files": "0",


### PR DESCRIPTION
Updated test data for scan event with new sizes in order to account for new ClamAV Engine

**Describe the change**
The ClamAV engine has updated and now exports slightly more specific information on its scan. This PR updates the associated test case to reflect this and will fix the issues with the nightly build in this repository and in the additional PR branches. 

**Describe testing procedures**
Tested with ClamAV test in pipeline. 

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
